### PR TITLE
Removed nframe, nskip, namp, subarray_bounds from yaml input

### DIFF
--- a/nircam_simulator/examples/imaging_test.yaml
+++ b/nircam_simulator/examples/imaging_test.yaml
@@ -4,14 +4,10 @@ Inst:
   use_JWST_pipeline: False   #Use pipeline in data transformations
 
 Readout:
-  readpatt: RAPID        #Readout pattern (RAPID, BRIGHT2, etc) overrides nframe,nskip unless it is not recognized
-  nframe: 1        #Number of frames per group
-  nskip: 0         #Number of skipped frames between groups
+  readpatt: RAPID        #Readout pattern (RAPID, BRIGHT2, etc)
   ngroup: 3              #Number of groups in integration
   nint: 1          #Number of integrations per exposure
-  namp: 4         #Number of amplifiers used in readout (4 for full frame, 1 for subarray)
-  array_name: NRCB5_FULL    #Name of array (FULL, SUB160, SUB64P, etc) overrides subarray_bounds below
-  subarray_bounds: 0, 0, 159, 159          #Coords of subarray corners. (xstart, ystart, xend, yend) Over-ridden by array_name above. Currently not used. Could be used if output saved in raw format
+  array_name: NRCB5_FULL    #Name of array (FULL, SUB160, SUB64P, etc)
   filter: F250M       #Filter of simulated data (F090W, F322W2, etc)
   pupil: CLEAR        #Pupil element for simulated data (CLEAR, GRISMC, etc)
 

--- a/nircam_simulator/examples/moving_target_test.yaml
+++ b/nircam_simulator/examples/moving_target_test.yaml
@@ -4,14 +4,10 @@ Inst:
   use_JWST_pipeline: False   #Use pipeline in data transformations
 
 Readout:
-  readpatt: RAPID        #Readout pattern (RAPID, BRIGHT2, etc) overrides nframe,nskip unless it is not recognized
-  nframe: 1        #Number of frames per group
-  nskip: 0         #Number of skipped frames between groups
+  readpatt: RAPID        #Readout pattern (RAPID, BRIGHT2, etc)
   ngroup: 7              #Number of groups in integration
   nint: 1          #Number of integrations per exposure
-  namp: 4         #Number of amplifiers used in readout (4 for full frame, 1 for subarray)
-  array_name: NRCB5_FULL    #Name of array (FULL, SUB160, SUB64P, etc) overrides subarray_bounds below
-  subarray_bounds: 0, 0, 159, 159          #Coords of subarray corners. (xstart, ystart, xend, yend) Over-ridden by array_name above. Currently not used. Could be used if output saved in raw format
+  array_name: NRCB5_FULL    #Name of array (FULL, SUB160, SUB64P, etc) 
   filter: F250M       #Filter of simulated data (F090W, F322W2, etc)
   pupil: CLEAR        #Pupil element for simulated data (CLEAR, GRISMC, etc)
 

--- a/nircam_simulator/examples/wfss_f250m_test.yaml
+++ b/nircam_simulator/examples/wfss_f250m_test.yaml
@@ -4,14 +4,10 @@ Inst:
   use_JWST_pipeline: False   #Use pipeline in data transformations
 
 Readout:
-  readpatt: RAPID        #Readout pattern (RAPID, BRIGHT2, etc) overrides nframe,nskip unless it is not recognized
-  nframe: 1        #Number of frames per group
-  nskip: 0         #Number of skipped frames between groups
+  readpatt: RAPID        #Readout pattern (RAPID, BRIGHT2, etc)
   ngroup: 3              #Number of groups in integration
   nint: 1          #Number of integrations per exposure
-  namp: 4         #Number of amplifiers used in readout (4 for full frame, 1 for subarray)
-  array_name: NRCB5_FULL    #Name of array (FULL, SUB160, SUB64P, etc) overrides subarray_bounds below
-  subarray_bounds: 0, 0, 159, 159          #Coords of subarray corners. (xstart, ystart, xend, yend) Over-ridden by array_name above. Currently not used. Could be used if output saved in raw format
+  array_name: NRCB5_FULL    #Name of array (FULL, SUB160, SUB64P, etc)
   filter: F250M       #Filter of simulated data (F090W, F322W2, etc)
   pupil: CLEAR        #Pupil element for simulated data (CLEAR, GRISMC, etc)
 

--- a/nircam_simulator/examples/wfss_f300m_test.yaml
+++ b/nircam_simulator/examples/wfss_f300m_test.yaml
@@ -4,14 +4,10 @@ Inst:
   use_JWST_pipeline: False   #Use pipeline in data transformations
 
 Readout:
-  readpatt: RAPID        #Readout pattern (RAPID, BRIGHT2, etc) overrides nframe,nskip unless it is not recognized
-  nframe: 1        #Number of frames per group
-  nskip: 0         #Number of skipped frames between groups
+  readpatt: RAPID        #Readout pattern (RAPID, BRIGHT2, etc)
   ngroup: 3              #Number of groups in integration
   nint: 1          #Number of integrations per exposure
-  namp: 4         #Number of amplifiers used in readout (4 for full frame, 1 for subarray)
-  array_name: NRCB5_FULL    #Name of array (FULL, SUB160, SUB64P, etc) overrides subarray_bounds below
-  subarray_bounds: 0, 0, 159, 159          #Coords of subarray corners. (xstart, ystart, xend, yend) Over-ridden by array_name above. Currently not used. Could be used if output saved in raw format
+  array_name: NRCB5_FULL    #Name of array (FULL, SUB160, SUB64P, etc)
   filter: F300M       #Filter of simulated data (F090W, F322W2, etc)
   pupil: CLEAR        #Pupil element for simulated data (CLEAR, GRISMC, etc)
 

--- a/nircam_simulator/examples/wfss_f410m_test.yaml
+++ b/nircam_simulator/examples/wfss_f410m_test.yaml
@@ -4,14 +4,10 @@ Inst:
   use_JWST_pipeline: False   #Use pipeline in data transformations
 
 Readout:
-  readpatt: RAPID        #Readout pattern (RAPID, BRIGHT2, etc) overrides nframe,nskip unless it is not recognized
-  nframe: 1        #Number of frames per group
-  nskip: 0         #Number of skipped frames between groups
+  readpatt: RAPID        #Readout pattern (RAPID, BRIGHT2, etc)
   ngroup: 3              #Number of groups in integration
   nint: 1          #Number of integrations per exposure
-  namp: 4         #Number of amplifiers used in readout (4 for full frame, 1 for subarray)
-  array_name: NRCB5_FULL    #Name of array (FULL, SUB160, SUB64P, etc) overrides subarray_bounds below
-  subarray_bounds: 0, 0, 159, 159          #Coords of subarray corners. (xstart, ystart, xend, yend) Over-ridden by array_name above. Currently not used. Could be used if output saved in raw format
+  array_name: NRCB5_FULL    #Name of array (FULL, SUB160, SUB64P, etc)
   filter: F410M       #Filter of simulated data (F090W, F322W2, etc)
   pupil: CLEAR        #Pupil element for simulated data (CLEAR, GRISMC, etc)
 

--- a/nircam_simulator/examples/wfss_f460m_test.yaml
+++ b/nircam_simulator/examples/wfss_f460m_test.yaml
@@ -4,14 +4,10 @@ Inst:
   use_JWST_pipeline: False   #Use pipeline in data transformations
 
 Readout:
-  readpatt: RAPID        #Readout pattern (RAPID, BRIGHT2, etc) overrides nframe,nskip unless it is not recognized
-  nframe: 1        #Number of frames per group
-  nskip: 0         #Number of skipped frames between groups
+  readpatt: RAPID        #Readout pattern (RAPID, BRIGHT2, etc)
   ngroup: 3              #Number of groups in integration
   nint: 1          #Number of integrations per exposure
-  namp: 4         #Number of amplifiers used in readout (4 for full frame, 1 for subarray)
-  array_name: NRCB5_FULL    #Name of array (FULL, SUB160, SUB64P, etc) overrides subarray_bounds below
-  subarray_bounds: 0, 0, 159, 159          #Coords of subarray corners. (xstart, ystart, xend, yend) Over-ridden by array_name above. Currently not used. Could be used if output saved in raw format
+  array_name: NRCB5_FULL    #Name of array (FULL, SUB160, SUB64P, etc)
   filter: F460M       #Filter of simulated data (F090W, F322W2, etc)
   pupil: CLEAR        #Pupil element for simulated data (CLEAR, GRISMC, etc)
 

--- a/nircam_simulator/scripts/dark_prep.py
+++ b/nircam_simulator/scripts/dark_prep.py
@@ -865,45 +865,19 @@ class DarkPrep():
             mtch = self.params['Readout']['readpatt'] == self.readpatterns['name']
             self.params['Readout']['nframe'] = self.readpatterns['nframe'][mtch].data[0]
             self.params['Readout']['nskip'] = self.readpatterns['nskip'][mtch].data[0]
-            print(('Requested readout pattern {}.'
-                  .format(self.params['Readout']['readpatt'])))
-            print(('Using the nframe and nskip values from the '
-                   'definition file:'))
-            print('{}'.format(self.params['Reffiles']['readpattdefs']))
-            print(('nframe = {} and nskip = {}.'
-                   .format(self.params['Readout']['nframe'],
+            print(('Requested readout pattern {} is valid. '
+                  'Using the nframe = {} and nskip = {}'
+                   .format(self.params['Readout']['readpatt'],
+                           self.params['Readout']['nframe'],
                            self.params['Readout']['nskip'])))
         else:
-            #if readpatt is not present in the definition file but the nframe/nskip combo is, then reset 
-            #readpatt to the appropriate value from the definition file
-            readpatt_nframe = self.readpatterns['nframe'].data
-            readpatt_nskip = self.readpatterns['nskip'].data
-            readpatt_name = self.readpatterns['name'].data
-            if self.params['Readout']['nframe'] in readpatt_nframe:
-                nfmtch = self.params['Readout']['nframe'] == readpatt_nframe
-                nskip_subset = readpatt_nskip[nfmtch]
-                name_subset = readpatt_name[nfmtch]
-                if self.params['Readout']['nskip'] in nskip_subset:
-                    finalmtch = self.params['Readout']['nskip'] == nskip_subset
-                    finalname = name_subset[finalmtch][0]
-                    print("CAUTION: requested readout pattern {} not recognized.".format(self.params['Readout']['readpatt']))
-                    print('but the requested nframe/nskip combination ({},{}), matches those values for'.format(self.params['Readout']['nframe'],self.params['Readout']['nskip']))
-                    print("the {} readout pattern, as listed in {}.".format(finalname,self.params['Reffiles']['readpattdefs']))
-                    print('Continuing on using that as the readout pattern.')
-                    self.params['Readout']['readpatt'] = finalname
-                else:
-                    #case where readpatt is not recognized, nframe is present in the definition file, but the nframe/nskip combination is not
-                    print('Unrecognized readout pattern {}, and the input nframe/nskip combination {},{} does not'.format(self.params['Readout']['readpatt'],self.params['Readout']['nframe'],self.params['Readout']['nskip']))
-                    print('match any present in {}. Continuing simulation with the input nframe/nskip, and'.format(self.params['Reffiles']['readpattdefs']))
-                    print("setting the readout pattern to 'ANY' in order to allow the output file to be saved via RampModel without error.")
-                    self.params['readpatt'] = 'ANY'
-            else:
-                #case where readpatt is not recognized, and nframe is not present in the definition file
-                print('Unrecognized readout pattern {}, and the input nframe/nskip combination {},{} does not'.format(self.params['Readout']['readpatt'],self.params['Readout']['nframe'],self.params['Readout']['nskip']))
-                print('match any present in {}. '.format(self.params['Reffiles']['readpattdefs']))
-                print('Continuing simulation with the input nframe/nskip values, and')
-                print("setting the readout pattern to 'ANY' in order to allow the output file to be saved via RampModel without error.")
-                self.params['readpatt'] = 'ANY'
+            # If the read pattern is not present in the definition file
+            # then quit.
+            print(("WARNING: the {} readout pattern is not defined in {}."
+                   .format(self.params['Readout']['readpatt'],
+                           self.params['Reffiles']['readpattdefs'])))
+            print("Quitting.")
+            sys.exit()
 
 
     def checkRunStep(self,filename):

--- a/nircam_simulator/scripts/obs_generator.py
+++ b/nircam_simulator/scripts/obs_generator.py
@@ -83,7 +83,8 @@ class Observation():
             print('Reading in dark file')
             self.linDark = self.readDarkFile(self.linDark)
             
-        # Finally, collect information about the detector, which will be needed for astrometry later
+        # Finally, collect information about the detector,
+        # which will be needed for astrometry later
         self.detector = self.linDark.header['DETECTOR']
         self.instrument = self.linDark.header['INSTRUME']
         self.fastaxis = self.linDark.header['FASTAXIS']
@@ -1308,8 +1309,9 @@ class Observation():
             nonlin[cof,:,:] = tmp
 
         # Crop to appropriate subarray
-        if "FULL" not in self.params['Readout']['array_name']:
-            nonlin = self.crop_to_subarray(nonlin)
+        # This is done in readCalFile
+        #if "FULL" not in self.params['Readout']['array_name']:
+        #    nonlin = self.crop_to_subarray(nonlin)
             
         return nonlin
     
@@ -2081,11 +2083,6 @@ class Observation():
     def readGainMap(self):
         # Read in the gain map. This will be used to
         # translate signals from e/s to ADU/sec
-        print('Is this necessary? flux calibration goes from')
-        print('magnitudes to adu/sec. Of course that doesnt account')
-        print('at all for varying gain across the detector...')
-        print('Cosmic rays from the library are in units of e/sec.')
-
         if self.runStep['gain']:
             self.gainim,self.gainhead = self.readCalFile(self.params['Reffiles']['gain'])
             #set any NaN's to 1.0
@@ -2162,7 +2159,8 @@ class Observation():
         # be collected using 4 amps. Subarray data will always be 1 amp,
         # except for the grism subarrays which span the entire width of
         # the detector. Those can be read out using 1 or 4 amps.
-        self.setNumAmps()
+        # THIS IS NOW DONE IN GETSUBARRAYBOUNDS
+        #self.setNumAmps()
 
         # Make sure that the requested number of groups is less than or
         # equal to the maximum allowed. 
@@ -2357,52 +2355,61 @@ class Observation():
                            self.params['Readout']['nframe'],
                            self.params['Readout']['nskip'])))
         else:
+            # If the read pattern is not present in the definition file
+            # then quit.
+            print(("WARNING: the {} readout pattern is not defined in {}."
+                   .format(self.params['Readout']['readpatt'],
+                           self.params['Reffiles']['readpattdefs'])))
+            print("Quitting.")
+            sys.exit()
+
+            
             # If read pattern is not present in the definition file but
             # the nframe/nskip combo is, then reset 
             # readpatt to the appropriate value from the definition file
-            readpatt_nframe = self.readpatterns['nframe'].data
-            readpatt_nskip = self.readpatterns['nskip'].data
-            readpatt_name = self.readpatterns['name'].data
-            if self.params['Readout']['nframe'] in readpatt_nframe:
-                nfmtch = self.params['Readout']['nframe'] == readpatt_nframe
-                nskip_subset = readpatt_nskip[nfmtch]
-                name_subset = readpatt_name[nfmtch]
-                if self.params['Readout']['nskip'] in nskip_subset:
-                    finalmtch = self.params['Readout']['nskip'] == nskip_subset
-                    finalname = name_subset[finalmtch][0]
-                    print(("CAUTION: requested readout pattern {} not recognized."
-                           .format(self.params['Readout']['readpatt'])))
-                    print(("but the requested nframe/nskip combination ({},{}), "
-                           "matches those values for".
-                           format(self.params['Readout']['nframe'],
-                                  self.params['Readout']['nskip'])))
-                    print(("the {} readout pattern, as listed in {}."
-                          .format(finalname,self.params['Reffiles']['readpattdefs'])))
-                    print('Continuing on using that as the readout pattern.')
-                    self.params['Readout']['readpatt'] = finalname
-                else:
-                    # Case where readpatt is not recognized, nframe is present
-                    # in the definition file, but nskip is not
-                    print(('Unrecognized readout pattern {}, and the input '
-                           'nframe/nskip combination {},{} does not'
-                           .format(self.params['Readout']['readpatt'],
-                                   self.params['Readout']['nframe'],
-                                   self.params['Readout']['nskip'])))
-                    print(('match any present in {}. This is not a valid NIRCam '
-                          'readout pattern. Quitting.'
-                          .format(self.params['Reffiles']['readpattdefs'])))
-                    sys.exit()
-            else:
-                # Case where readpatt and nframe are not recognized
-                print(('Unrecognized readout pattern {}, and the input '
-                       'nframe/nskip combination {},{} does not'
-                       .format(self.params['Readout']['readpatt'],
-                               self.params['Readout']['nframe'],
-                               self.params['Readout']['nskip'])))     
-                print(('match any present in {}. This is not a valid NIRCam '
-                       'readout pattern. Quitting.'
-                       .format(self.params['Reffiles']['readpattdefs'])))
-                sys.exit()
+            #readpatt_nframe = self.readpatterns['nframe'].data
+            #readpatt_nskip = self.readpatterns['nskip'].data
+            #readpatt_name = self.readpatterns['name'].data
+            #if self.params['Readout']['nframe'] in readpatt_nframe:
+            #    nfmtch = self.params['Readout']['nframe'] == readpatt_nframe
+            #    nskip_subset = readpatt_nskip[nfmtch]
+            #    name_subset = readpatt_name[nfmtch]
+            #    if self.params['Readout']['nskip'] in nskip_subset:
+            #        finalmtch = self.params['Readout']['nskip'] == nskip_subset
+            #        finalname = name_subset[finalmtch][0]
+            #        print(("CAUTION: requested readout pattern {} not recognized."
+            #               .format(self.params['Readout']['readpatt'])))
+            #        print(("but the requested nframe/nskip combination ({},{}), "
+            #               "matches those values for".
+            #               format(self.params['Readout']['nframe'],
+            #                      self.params['Readout']['nskip'])))
+            #        print(("the {} readout pattern, as listed in {}."
+            #              .format(finalname,self.params['Reffiles']['readpattdefs'])))
+            #        print('Continuing on using that as the readout pattern.')
+            #        self.params['Readout']['readpatt'] = finalname
+            #    else:
+            #        # Case where readpatt is not recognized, nframe is present
+            #        # in the definition file, but nskip is not
+            #        print(('Unrecognized readout pattern {}, and the input '
+            #               'nframe/nskip combination {},{} does not'
+            #               .format(self.params['Readout']['readpatt'],
+            #                       self.params['Readout']['nframe'],
+            #                       self.params['Readout']['nskip'])))
+            #        print(('match any present in {}. This is not a valid NIRCam '
+            #              'readout pattern. Quitting.'
+            #              .format(self.params['Reffiles']['readpattdefs'])))
+            #        sys.exit()
+            #else:
+            #    # Case where readpatt and nframe are not recognized
+            #    print(('Unrecognized readout pattern {}, and the input '
+            #           'nframe/nskip combination {},{} does not'
+            #           .format(self.params['Readout']['readpatt'],
+            #                   self.params['Readout']['nframe'],
+            #                   self.params['Readout']['nskip'])))     
+            #    print(('match any present in {}. This is not a valid NIRCam '
+            #           'readout pattern. Quitting.'
+            #           .format(self.params['Reffiles']['readpattdefs'])))
+            #    sys.exit()
 
 
     def setNumAmps(self):
@@ -2411,11 +2418,13 @@ class Observation():
         # generally use 1 amp, except for the grism-related
         # subarrays that span the entire width
         # of the detector. For those, trust that the user input is what they want.
+        amps = 4
         if "FULL" in self.params['Readout']['array_name'].upper():
-            self.params['Readout']['namp'] = 4
+            amps = 4
         else:
             if self.subarray_bounds[2]-self.subarray_bounds[0] != 2047:
-                self.params['Readout']['namp'] = 1
+                amps = 1
+        self.params['Readout']['namp'] = amps
 
                   
     def checkParamVal(self,value,typ,vmin,vmax,default):


### PR DESCRIPTION
These parameters are no longer user inputs. They are all determined from the array_name parameter, in concert with the definitions in the subarray and readout pattern files.

I had kept them as inputs for cases where a user may want to experiment with non-standard readout patterns. But that is not going to be a very common use of the software. And, that experimentation can still be done by adding new definitions to the subarray and/or readout pattern definition files.

Also fixed a bug where the linearity coefficients were being improperly cropped in the obs_generator in the case of a subarray.