### PR TITLE
Added ability to specify background with high/medium/low

### DIFF
--- a/nircam_simulator/examples/imaging_test.yaml
+++ b/nircam_simulator/examples/imaging_test.yaml
@@ -32,7 +32,8 @@ Reffiles:                                 #Set to None or leave blank if you wis
   crosstalk:       config   #File containing crosstalk coefficients
   filtpupilcombo:  config   #File that lists the filter wheel element / pupil wheel element combinations. Used only in writing output file
   flux_cal:        config   #File that lists flux conversion factor and pivot wavelength for each filter. Only used when making direct image outputs to be fed into the grism disperser code.
-  
+  filter_throughput: config #File containing filter throughput curve
+
 nonlin:
   limit: 60000.0                           #Upper singal limit to which nonlinearity is applied (ADU)
   accuracy: 0.000001                        #Non-linearity accuracy threshold
@@ -67,7 +68,7 @@ simSignals:
   zodiscale:  1.0                            #Zodi scaling factor
   scattered:  None                          #Scattered light count rate image file
   scatteredscale: 1.0                        #Scattered light scaling factor
-  bkgdrate: 0.0                         #Constant background count rate (electrons/sec/pixel)
+  bkgdrate: medium                         #Constant background count rate. Number (ADU/sec/pixel) or 'high','medium','low' similar to what is used in the ETC
   poissonseed: 2012872553                  #Random number generator seed for Poisson simulation)
   photonyield: True                         #Apply photon yield in simulation
   pymethod: True                            #Use double Poisson simulation for photon yield

--- a/nircam_simulator/examples/moving_target_test.yaml
+++ b/nircam_simulator/examples/moving_target_test.yaml
@@ -32,7 +32,8 @@ Reffiles:                                 #Set to None or leave blank if you wis
   crosstalk:       config   #File containing crosstalk coefficients
   filtpupilcombo:  config   #File that lists the filter wheel element / pupil wheel element combinations. Used only in writing output file
   flux_cal:        config   #File that lists flux conversion factor and pivot wavelength for each filter. Only used when making direct image outputs to be fed into the grism disperser code.
-  
+  filter_throughput: config #File containing filter throughput curve
+
 nonlin:
   limit: 60000.0                           #Upper singal limit to which nonlinearity is applied (ADU)
   accuracy: 0.000001                        #Non-linearity accuracy threshold

--- a/nircam_simulator/examples/wfss_f250m_test.yaml
+++ b/nircam_simulator/examples/wfss_f250m_test.yaml
@@ -32,7 +32,8 @@ Reffiles:                                 #Set to None or leave blank if you wis
   crosstalk:       config   #File containing crosstalk coefficients
   filtpupilcombo:  config   #File that lists the filter wheel element / pupil wheel element combinations. Used only in writing output file
   flux_cal:        config   #File that lists flux conversion factor and pivot wavelength for each filter. Only used when making direct image outputs to be fed into the grism disperser code.
-  
+  filter_throughput: config #File containing filter throughput curve
+
 nonlin:
   limit: 60000.0                           #Upper singal limit to which nonlinearity is applied (ADU)
   accuracy: 0.000001                        #Non-linearity accuracy threshold

--- a/nircam_simulator/examples/wfss_f300m_test.yaml
+++ b/nircam_simulator/examples/wfss_f300m_test.yaml
@@ -32,7 +32,8 @@ Reffiles:                                 #Set to None or leave blank if you wis
   crosstalk:       config   #File containing crosstalk coefficients
   filtpupilcombo:  config   #File that lists the filter wheel element / pupil wheel element combinations. Used only in writing output file
   flux_cal:        config   #File that lists flux conversion factor and pivot wavelength for each filter. Only used when making direct image outputs to be fed into the grism disperser code.
-  
+  filter_throughput: config #File containing filter throughput curve
+
 nonlin:
   limit: 60000.0                           #Upper singal limit to which nonlinearity is applied (ADU)
   accuracy: 0.000001                        #Non-linearity accuracy threshold

--- a/nircam_simulator/examples/wfss_f410m_test.yaml
+++ b/nircam_simulator/examples/wfss_f410m_test.yaml
@@ -32,7 +32,8 @@ Reffiles:                                 #Set to None or leave blank if you wis
   crosstalk:       config   #File containing crosstalk coefficients
   filtpupilcombo:  config   #File that lists the filter wheel element / pupil wheel element combinations. Used only in writing output file
   flux_cal:        config   #File that lists flux conversion factor and pivot wavelength for each filter. Only used when making direct image outputs to be fed into the grism disperser code.
-  
+  filter_throughput: config #File containing filter throughput curve
+
 nonlin:
   limit: 60000.0                           #Upper singal limit to which nonlinearity is applied (ADU)
   accuracy: 0.000001                        #Non-linearity accuracy threshold

--- a/nircam_simulator/examples/wfss_f460m_test.yaml
+++ b/nircam_simulator/examples/wfss_f460m_test.yaml
@@ -32,7 +32,8 @@ Reffiles:                                 #Set to None or leave blank if you wis
   crosstalk:       config   #File containing crosstalk coefficients
   filtpupilcombo:  config   #File that lists the filter wheel element / pupil wheel element combinations. Used only in writing output file
   flux_cal:        config   #File that lists flux conversion factor and pivot wavelength for each filter. Only used when making direct image outputs to be fed into the grism disperser code.
-  
+  filter_throughput: config #File containing filter throughput curve
+
 nonlin:
   limit: 60000.0                           #Upper singal limit to which nonlinearity is applied (ADU)
   accuracy: 0.000001                        #Non-linearity accuracy threshold


### PR DESCRIPTION
User can now specify the constant background as a rate, using a number (ADU/sec/pixel), or with one of "high", "medium", or "low", as is used for the ETC. If the high/medium/low value is used, then jwst_backgrounds is used to calculate the background level. 

"high" corresponds to the 90th percentile of the backgrounds over a year's visibility for the given RA,Dec.
"medium" is 50th percentile.
"low" is 10th percentile.

In order to perform these calculations, we also need to add filter throughput curves to the repo.