### PR TITLE
Fixed bug in the way the dark generator was grouping frames

### DIFF
--- a/nircam_simulator/scripts/dark_prep.py
+++ b/nircam_simulator/scripts/dark_prep.py
@@ -643,7 +643,8 @@ class DarkPrep():
             
             # Loop over integrations
             for integ in range(self.params['Readout']['nint']):
-                frames = np.arange(self.params['Readout']['nskip'],framesPerGroup)
+                #frames = np.arange(self.params['Readout']['nskip'],framesPerGroup)
+                frames = np.arange(0,self.params['Readout']['nframe'])
                 
                 # Loop over groups
                 for i in range(self.params['Readout']['ngroup']):

--- a/nircam_simulator/scripts/obs_generator.py
+++ b/nircam_simulator/scripts/obs_generator.py
@@ -239,8 +239,6 @@ class Observation():
                                                       save_accuracy_map = savefile,
                                                       accuracy_file = ofile)
 
-                print("after unlinearizing: {}".format(raw_outramp[0,:,1000,1000]))
-
                 raw_zeroframe = unlinearize.unlinearize(lin_zeroframe,nonlincoeffs,self.satmap,
                                                         lin_satmap,
                                                         maxiter = self.params['nonlin']['maxiter'],
@@ -250,12 +248,6 @@ class Observation():
                 # Add the superbias and reference pixel signal back in
                 #raw_outramp = self.add_sbAndRefPix(raw_outramp,self.linDark.sbAndRefpix)
                 raw_outramp = self.add_sbAndRefPix(raw_outramp,lin_sbAndRefpix)
-
-                print("after adding sb and refpix back in: {}".format(raw_outramp[0,:,1000,1000]))
-                print("sb and refpix signal: {}".format(self.linDark.sbAndRefpix[0,:,1000,1000]))
-                print("NEED TO rearrange linDark.sbAndRefpix for readpatt, just like was done for the dark itself")
-                      
-                      
                 raw_zeroframe = self.add_sbAndRefPix(raw_zeroframe,self.linDark.zero_sbAndRefpix)
 
                 # Make sure all signals are < 65535
@@ -1497,8 +1489,6 @@ class Observation():
         #    print("the requested output readout pattern.")
         #    sys.exit()
 
-        print("After adding dark current: {}".format(synthetic[0,:,1000,1000]))
-            
         return synthetic,zeroframe,reorder_sbandref
 
 
@@ -1540,8 +1530,6 @@ class Observation():
 
         if self.runStep['pixelAreaMap']:
             ramp = self.addPAM(ramp)
-
-        print("After detector effects: {}".format(ramp[0,:,1000,1000]))
 
         return ramp
 


### PR DESCRIPTION
This is a fix of the same bug that had also been in the obs_generator. The first group is composed of nframes, but no frames are skipped until the beginning of the second group. Previously the initial nkip frames were being skipped.

I also removed a few residual print statement in obs_generator that were leftover from testing, and made the code crash for subarrays, since they were printing pixel values in pixel 1000,1000.