### PR TITLE
Velocities in input source catalogs now all per hour

### DIFF
--- a/nircam_simulator/catalogs/moving_galaxies.list
+++ b/nircam_simulator/catalogs/moving_galaxies.list
@@ -12,6 +12,14 @@
 #
 #pos_angle is the position angle of the semimajor axis, in degrees.
 #0 causes the semi-major axis to be horizontal.
+#
+#x_or_RA_velocity is the velocity in the increasing x or RA direction
+#in units of arcsec/hour. To specify units in the x-direction, place
+#'velocity_pixels' (alone) in one of the top 4 lines of the file.
+#
+#y_or_Dec_velocity is the velocity in the increasing y or Dec direction
+#in units of arcsec/hour. To specify units in the y-direction, place
+#'velocity_pixels' (alone) in one of the top 4 lines of the file.
 x_or_RA    y_or_Dec  radius  ellipticity  pos_angle  sersic_index  magnitude  x_or_RA_velocity y_or_Dec_velocity
 23:59:59.9986 +00:00:00.0047  1.0      0.25        20           2.0  16.000        -0.5               -0.02
 00:00:00.0003 +00:00:00.0216  1.5      0.5         79           1.2  16.000        -0.5               -0.02

--- a/nircam_simulator/catalogs/moving_target_extended.list
+++ b/nircam_simulator/catalogs/moving_target_extended.list
@@ -6,11 +6,11 @@
 #This is the method to use in order to create moving targets of 
 #extended sources, like planets, moons, etc.
 #position can be x,y or RA,Dec. If x,y, put the word 'pixels' in the top
-#line of the file. Velocity can be in units of pix/sec or arcsec/sec.
-#If using pix/sec, place 'velocity_pixels' in the second line of the file.
-#Note that if using velocities of pix/sec, the results will not be 
+#line of the file. Velocity can be in units of pix/hour or arcsec/hour.
+#If using pix/hour, place 'velocity_pixels' in the second line of the file.
+#Note that if using velocities of pix/hour, the results will not be 
 #strictly correct because in reality distortion will cause object's
-#velocities to vary in pixels/sec. Velocities in arcsec/sec will be
+#velocities to vary in pixels/hour. Velocities in arcsec/hour will be
 #constant.
 filename    x_or_RA    y_or_Dec   magnitude pos_angle  x_or_RA_velocity y_or_Dec_velocity
 ring_nebula.fits 0.007   0.003      12.0      0.0       -0.5               -0.02

--- a/nircam_simulator/catalogs/moving_target_to_track.cat
+++ b/nircam_simulator/catalogs/moving_target_to_track.cat
@@ -2,14 +2,21 @@
 #
 # 
 # abmag 
-# x and y can be pixel values, or RA and Dec strings or floats. To differentiate, put 'pixels' in the top line if the inputs are pixel values.
-# radius can also be in units of pixels or arcseconds. Put 'radius_pixels' at top of file to specify radii in pixels.
-# position angle is given in degrees counterclockwise. A value of 0 will align the semimajor axis with the x axis of the detector.
-#An object value containing 'point' will be interpreted as a point source. 
-#Anything containing 'sersic' will create a 2D sersic profile.
-# Any other value will be interpreted as an extended source.
-#x_or_RA_velocity is the proper motion of the target in units of arcsec (or pixels) per year
-#Y_or_Dec_velocity is the proper motion of the target in units of arcsec (or pixels) per year
-#if the units are pixels per year, include 'velocity pixels' in line 2 above.
+# x and y can be pixel values, or RA and Dec strings or floats.
+# To differentiate, put 'pixels' in the top line (alone) if the inputs are
+# pixel values.
+# Radius can also be in units of pixels or arcseconds. Put 'radius_pixels'
+# in one of the top 4 lines (alone) if units are pixels.
+# x_or_RA_velocity is the proper motion of the target in the increasing
+# RA- or x-direction, in units of arcsec (or pixels) per hour
+# y_or_Dec_velocity is the proper motion of the target in the increasing
+# Dec- or y-direction, in units of arcsec (or pixels) per hour
+# If the units are pixels per hour, include 'velocity pixels' (alone) in
+# one of the top 4 lines above.
+# Position angle is given in degrees counterclockwise. A value of 0
+# will align the semimajor axis with the x axis of the detector.
+# In the "object" column, a value containing 'point' will be interpreted
+# as a point source. An entry containing 'sersic' will create a 2D sersic
+# profile. Any other value will be interpreted as an extended source.
 object x_or_RA y_or_Dec x_or_RA_velocity  y_or_Dec_velocity magnitude
-pointSource  53.101 -27.801  2103840. 0.0 17.
+pointSource  53.101 -27.801  240. 0.0 17.

--- a/nircam_simulator/scripts/catalog_seed_image.py
+++ b/nircam_simulator/scripts/catalog_seed_image.py
@@ -330,7 +330,7 @@ class Catalog_seed():
         #moving target using an extended object
         if self.runStep['movingTargetsExtended']:
             #print("Extended moving targets!!!")
-            mov_targs_ext, mt_ext_segmap = self.movingTargetInputs(self.params['simSignals']['movingTargetExtended'],'extended',MT_tracking=tracking,ra_vel=tracking_ra_vel,dec_vel=tracking_dec_val)
+            mov_targs_ext, mt_ext_segmap = self.movingTargetInputs(self.params['simSignals']['movingTargetExtended'],'extended',MT_tracking=tracking,tracking_ra_vel=ra_vel,tracking_dec_vel=dec_val)
             mov_targs_ramps.append(mov_targs_ext)
             if mov_targs_segmap is None:
                 mov_targs_segmap = np.copy(mt_ext_segmap)
@@ -518,13 +518,13 @@ class Catalog_seed():
                 # target. If it doesn't, then we have sidereal
                 # targets, and we can simply set their velocity
                 # as the inverse of that being tracked.
-                mtlist['x_or_RA_velocity'] -= tracking_ra_vel * (1./365.25/24.)
-                mtlist['y_or_Dec_velocity'] -= tracking_dec_vel * (1./365.25/24.)
+                mtlist['x_or_RA_velocity'] -= tracking_ra_vel #* (1./365.25/24.)
+                mtlist['y_or_Dec_velocity'] -= tracking_dec_vel #* (1./365.25/24.)
                 pixvelflag = trackingPixVelFlag
             except:
                 print('Setting velocity of targets equal to the non-sidereal tracking velocity')
-                mtlist['x_or_RA_velocity'] = 0. - tracking_ra_vel * (1./365.25/24.)
-                mtlist['y_or_Dec_velocity'] = 0. - tracking_dec_vel * (1./365.25/24.)
+                mtlist['x_or_RA_velocity'] = 0. - tracking_ra_vel #* (1./365.25/24.)
+                mtlist['y_or_Dec_velocity'] = 0. - tracking_dec_vel #* (1./365.25/24.)
                 pixvelflag = trackingPixVelFlag
 
         #get necessary information for coordinate transformations
@@ -655,8 +655,6 @@ class Catalog_seed():
             else:
                 indseg = self.seg_from_photutils(mt_source[-1,:,:],index,noiseval)
                 moving_segmap.segmap += indseg
-            print('movingTargetInputs, index {}, min,max segmap {},{}'.format(index,np.min(moving_segmap.segmap),np.max(moving_segmap.segmap)))
-                
         return mt_integration, moving_segmap.segmap
 
     


### PR DESCRIPTION
Previously the time component of the velocity units were different for different types of moving targets. Now, all catalogs that have a velocity input assume the velocity is in units of arcsec/hour or pixels/hour. This resolves issue #26 