### PR TITLE
Added ability to have multiple integrations with moving targets

### DIFF
--- a/nircam_simulator/examples/imaging_test.yaml
+++ b/nircam_simulator/examples/imaging_test.yaml
@@ -7,6 +7,7 @@ Readout:
   readpatt: RAPID        #Readout pattern (RAPID, BRIGHT2, etc)
   ngroup: 3              #Number of groups in integration
   nint: 1          #Number of integrations per exposure
+  resets_bet_ints: 1 #Number of detector resets between integrations
   array_name: NRCB5_FULL    #Name of array (FULL, SUB160, SUB64P, etc)
   filter: F250M       #Filter of simulated data (F090W, F322W2, etc)
   pupil: CLEAR        #Pupil element for simulated data (CLEAR, GRISMC, etc)
@@ -22,7 +23,7 @@ Reffiles:                                 #Set to None or leave blank if you wis
   pixelflat: None 
   illumflat: None                               #Illumination flat field file
   astrometric: /ifs/jwst/wit/nircam/nircam_simulator_data/reference_files/distortion/NRCB5_FULL_distortion.asdf  #Astrometric distortion file (asdf)
-  distortion_coeffs: /ifs/jwst/wit/nircam/nircam_simulator_data/reference_files/SIAF/NIRCam_SIAF_2017-03-28.csv        #CSV file containing distortion coefficients
+  distortion_coeffs: /ifs/jwst/wit/nircam/nircam_simulator_data/reference_files/SIAF/NIRCam_SIAF_2018-01-08.csv        #CSV file containing distortion coefficients
   ipc: /ifs/jwst/wit/nircam/nircam_simulator_data/reference_files/ipc/NRCB5_17161_IPCDeconvolutionKernel_2016-03-18_ssbipc_DMSorient.fits #File containing IPC kernel to apply
   invertIPC: True       #Invert the IPC kernel before the convolution. True or False. Use True if the kernel is designed for the removal of IPC effects, like the JWST reference files are.
   occult: None                                    #Occulting spots correction image

--- a/nircam_simulator/examples/moving_target_test.yaml
+++ b/nircam_simulator/examples/moving_target_test.yaml
@@ -7,6 +7,7 @@ Readout:
   readpatt: RAPID        #Readout pattern (RAPID, BRIGHT2, etc)
   ngroup: 7              #Number of groups in integration
   nint: 1          #Number of integrations per exposure
+  resets_bet_ints: 1 #Number of detector resets between integrations
   array_name: NRCB5_FULL    #Name of array (FULL, SUB160, SUB64P, etc) 
   filter: F250M       #Filter of simulated data (F090W, F322W2, etc)
   pupil: CLEAR        #Pupil element for simulated data (CLEAR, GRISMC, etc)

--- a/nircam_simulator/examples/wfss_f250m_test.yaml
+++ b/nircam_simulator/examples/wfss_f250m_test.yaml
@@ -7,6 +7,7 @@ Readout:
   readpatt: RAPID        #Readout pattern (RAPID, BRIGHT2, etc)
   ngroup: 3              #Number of groups in integration
   nint: 1          #Number of integrations per exposure
+  resets_bet_ints: 1 #Number of detector resets between integrations
   array_name: NRCB5_FULL    #Name of array (FULL, SUB160, SUB64P, etc)
   filter: F250M       #Filter of simulated data (F090W, F322W2, etc)
   pupil: CLEAR        #Pupil element for simulated data (CLEAR, GRISMC, etc)

--- a/nircam_simulator/examples/wfss_f300m_test.yaml
+++ b/nircam_simulator/examples/wfss_f300m_test.yaml
@@ -7,6 +7,7 @@ Readout:
   readpatt: RAPID        #Readout pattern (RAPID, BRIGHT2, etc)
   ngroup: 3              #Number of groups in integration
   nint: 1          #Number of integrations per exposure
+  resets_bet_ints: 1 #Number of detector resets between integrations
   array_name: NRCB5_FULL    #Name of array (FULL, SUB160, SUB64P, etc)
   filter: F300M       #Filter of simulated data (F090W, F322W2, etc)
   pupil: CLEAR        #Pupil element for simulated data (CLEAR, GRISMC, etc)

--- a/nircam_simulator/examples/wfss_f410m_test.yaml
+++ b/nircam_simulator/examples/wfss_f410m_test.yaml
@@ -7,6 +7,7 @@ Readout:
   readpatt: RAPID        #Readout pattern (RAPID, BRIGHT2, etc)
   ngroup: 3              #Number of groups in integration
   nint: 1          #Number of integrations per exposure
+  resets_bet_ints: 1 #Number of detector resets between integrations
   array_name: NRCB5_FULL    #Name of array (FULL, SUB160, SUB64P, etc)
   filter: F410M       #Filter of simulated data (F090W, F322W2, etc)
   pupil: CLEAR        #Pupil element for simulated data (CLEAR, GRISMC, etc)

--- a/nircam_simulator/examples/wfss_f460m_test.yaml
+++ b/nircam_simulator/examples/wfss_f460m_test.yaml
@@ -7,6 +7,7 @@ Readout:
   readpatt: RAPID        #Readout pattern (RAPID, BRIGHT2, etc)
   ngroup: 3              #Number of groups in integration
   nint: 1          #Number of integrations per exposure
+  resets_bet_ints: 1 #Number of detector resets between integrations
   array_name: NRCB5_FULL    #Name of array (FULL, SUB160, SUB64P, etc)
   filter: F460M       #Filter of simulated data (F090W, F322W2, etc)
   pupil: CLEAR        #Pupil element for simulated data (CLEAR, GRISMC, etc)

--- a/nircam_simulator/scripts/moving_targets.py
+++ b/nircam_simulator/scripts/moving_targets.py
@@ -1,9 +1,32 @@
 #! /usr/bin/env python
 
 '''
-Class that simulates moving targets as viewed on a JWST instrument. Written
-to accompany ramp_simulator.py
+Class that creates an integration containing multiple frames and 
+shows a source that is moving relative to the detector. Called by 
+nircam_simualtor.py. 
 
+Arguments:
+----------
+stamp -- 2D stamp image containing target
+xframes -- list of x-coordinate pixel position of target
+           in each frame
+yframes -- list of y-coordinate pixel position of target
+           in each frame
+frametime -- exposure time in seconds corresponding to one 
+             detector readout (varies with subarray size)
+outx -- x-dimension size of the output aperture (2048 for
+        full-frame)
+outy -- y-dimension size of the output aperture (2048 for
+        full-frame)
+
+Returns:
+--------
+3D array containing the signal of the source in each frame
+of the integration
+
+Author:
+-------
+Bryan Hilbert
 '''
 
 from astropy.io import fits
@@ -18,74 +41,68 @@ class MovingTarget():
         self.subsampx = 3
         self.subsampy = 3
 
-    #def create(self,stamp,xinit,yinit,rate,posang,frametime,numframes,subsample_factor,outx,outy):
-    #def create(self,stamp,rainit,decinit,rarate,decrate,frametime,numframes,subsample_factor,outx,outy):
-    def create(self,stamp,xframes,yframes,frametime,outx,outy):
-        #inputs include the stamp image of the object, the initial
-        #x and y location, the rate at which the object is moving
-        #(in pixels/sec) and the position angle (degrees), to describe the
-        #direction in which the object is moving.
-        
-        #assume xinit is ra,dec. time calc stays same.
-        #velocity is arcsec/sec
-        #assume an ra_velocity and dec_velocity input
-        #xframes,yframes then in ra,dec
-        #translate xframes,yframes to x,y
+    def create(self, stamp, xframes, yframes, frametime, outx, outy):
+        """
+        MAIN FUNCTION
 
-        #make sure subsampling factor is an integer
+        Arguments:
+        ----------
+        stamp -- 2D stamp image containing target
+        xframes -- list of x-coordinate pixel position of target
+                   in each frame
+        yframes -- list of y-coordinate pixel position of target
+                   in each frame
+        frametime -- exposure time in seconds corresponding to one 
+                     detector readout (varies with subarray size)
+        outx -- x-dimension size of the output aperture (2048 for
+                full-frame)
+        outy -- y-dimension size of the output aperture (2048 for
+                full-frame)
+
+        Returns:
+        --------
+        3D array containing the signal of the source in each frame
+        of the integration
+        """
+        
+        # Make sure subsampling factor is an integer
         self.subsampx = np.int(self.subsampx)
         self.subsampy = np.int(self.subsampy)
 
-        #quick fix for the case where xinit,yinit are integers
+        # Quick fix for the case where xinit,yinit are integers
         xinit = np.float(xframes[1])
         yinit = np.float(yframes[1])
 
-        #change position angle to radians
+        # Change position angle to radians
         #posang = posang * np.pi / 180.
 
-        #inverse rate
-        #rate = np.sqrt(rarate*rarate + decrate*decrate)
-        #secPerPix = 1./ rate
-        #CALCULATE THIS WITHIN EACH FRAME
-        
-        #list of times for all frames
+        # List of times for all frames
         numframes = len(xframes)-1
-        times = frametime * np.arange(-1,numframes)
+        times = frametime * np.arange(-1, numframes)
 
-        #list of RA,Dec positions for all frames
-        #raframes,decframes = self.radecPerFrame(xinit,yinit,rarate,decrate,time)
-        #raframes = rainit + rarate*times
-        #decrames = decinit + decrate*times
-        
-        #calculate the x,y location of the object in each frame
-        #Include the x,y location at the time of detector reset,
-        #so that we can generate a realistic frame 0.
-        #xframes,yframes = self.xyPerFrame(rate,times,posang,xinit,yinit)
+        # Generate a list of locations at dist-pixel increments
+        # between the beginning and ending locations
+        xs, ys = self.equidistantXY(xframes[0], yframes[0], xframes[-1],
+                                    yframes[-1], 1./self.subsampx)
 
-        #generate a list of locations at dist-pixel increments
-        #between the beginning and ending locations
-        xs, ys = self.equidistantXY(xframes[0],yframes[0],xframes[-1],yframes[-1],1./self.subsampx) #,posang)
-        #print('xs,ys',xs,ys)
-
-        #subsample the PSF image
-        substamp = self.subsample(stamp,self.subsampx,self.subsampy)
+        # Subsample the PSF image
+        substamp = self.subsample(stamp, self.subsampx, self.subsampy)
         substamplen = substamp.shape
 
-        #create the initial output frame
-        ystamplen,xstamplen = stamp.shape
+        # Create the initial output frame
+        ystamplen, xstamplen = stamp.shape
         #minx = np.min([np.floor(xinit) - np.ceil(xstamplen/2.),np.floor(xframes[-1])-np.ceil(xstamplen/2.)])
-        minx = np.int(np.min([np.floor(xframes[0]) - np.ceil(xstamplen/2.),np.floor(xframes[-1])-np.ceil(xstamplen/2.)]))        
-
-        #print(xinit,xstamplen/2,xframes[-1])
-        #print("intially, mnx is: {}".format(minx))
-        maxx = np.int(np.max([np.floor(xframes[-1] + xstamplen/2.),np.floor(xframes[0]+xstamplen/2.)]))
-        #print('maxx is {}. xframes[0] and [-1] are {},{}, stamplen is {}'.format(maxx,xframes[0],xframes[-1],xstamplen))
+        minx = np.int(np.min([np.floor(xframes[0]) - np.ceil(xstamplen/2.),\
+                              np.floor(xframes[-1])-np.ceil(xstamplen/2.)]))
+        maxx = np.int(np.max([np.floor(xframes[-1] + xstamplen/2.),\
+                              np.floor(xframes[0]+xstamplen/2.)]))
         #miny = np.min([np.floor(yinit) - np.ceil(ystamplen/2.),np.floor(yframes[-1])-np.ceil(ystamplen/2.)])
-        miny = np.int(np.min([np.floor(yframes[0]) - np.ceil(ystamplen/2.),np.floor(yframes[-1])-np.ceil(ystamplen/2.)]))
+        miny = np.int(np.min([np.floor(yframes[0]) - np.ceil(ystamplen/2.),\
+                              np.floor(yframes[-1])-np.ceil(ystamplen/2.)]))
+        maxy = np.int(np.max([np.floor(yframes[-1] + ystamplen/2.),\
+                              np.floor(yframes[0]+ystamplen/2.)]))
 
-        maxy = np.int(np.max([np.floor(yframes[-1] + ystamplen/2.),np.floor(yframes[0]+ystamplen/2.)]))
-
-        #Don't let stamps fall off the edges of the output array
+        # Don't let stamps fall off the edges of the output array
         mnx = minx
         mxx = maxx
         mny = miny
@@ -99,30 +116,18 @@ class MovingTarget():
         if maxy > outy:
             mxy = np.int(outy-1)
 
-        #print("Now, minx is {}".format(mnx))
-        #sys.exit()
-
-        #subsample the output frame
+        # Subsample the output frame
         totxpoints = np.min([outx,mxx-mnx+1])
         totypoints = np.min([outy,mxy-mny+1])
-        #print('totxpoints,outx,mxx,mnx',totxpoints,outx,mxx,mnx)
-        #print('totypoints,outy,mxy,mny',totypoints,outy,mxy,mny)
-        #print(totypoints,self.subsampy,totxpoints,self.subsampx,outx,mnx,mxx,mny,mxy)
-        #print(minx,maxx,miny,maxy)
-        outputframe0 = np.zeros((np.int(totypoints*self.subsampy),np.int(totxpoints*self.subsampx)))
-        #sys.exit()
-        outputframe1 = np.zeros((np.int(totypoints*self.subsampy),np.int(totxpoints*self.subsampx)))
-        outfull = np.zeros((numframes,outy,outx))
+        outputframe0 = np.zeros((np.int(totypoints*self.subsampy),\
+                                 np.int(totxpoints*self.subsampx)))
+        outputframe1 = np.zeros((np.int(totypoints*self.subsampy),\
+                                 np.int(totxpoints*self.subsampx)))
+        outfull = np.zeros((numframes, outy, outx))
         outsubshape = outputframe0.shape
 
-        #print('x,y stamp size',xstamplen,ystamplen)
-        #print("miny,maxy in full frame coords: ",miny,maxy)
-        #print("minx,maxx in full frame coords: ",minx,maxx)
-        #print('xframes in full frame coords:',xframes)
-        #print('yframes in full frame coords:',yframes)
-
-        #translate the source location x and y values to the coordinates
-        #of the output frame
+        # Translate the source location x and y values to the coordinates
+        # of the output frame
         deltacenterx = np.round(self.subsampx / 2. - 1 + 0.000001)
         deltacentery = np.round(self.subsampy / 2. - 1 + 0.000001)
         xframessub = np.round((xframes-mnx) * self.subsampx) + deltacenterx
@@ -130,50 +135,13 @@ class MovingTarget():
         xssub = np.round((xs-mnx) * self.subsampx) + deltacenterx
         yssub = np.round((ys-mny) * self.subsampy) + deltacentery
 
-        #print('xssub',xssub)
-        #print('yssub',yssub)
-
-        #now create the multiple-frame integration using subsampled frames
-
-        #check to see if the source is off, or partially off the detector. 
-        #Adjust coordinate indexes as necessary, and keep track of coordinates
-        #in the stamp image
-        #outxmin,outxmax,stampxmin,stampxmax = self.coordCheck(xframessub[1],substamplen[1],outsubshape[1])
-        #outymin,outymax,stampymin,stampymax = self.coordCheck(xframessub[0],substamplen[0],outsubshape[0])
-
-        #print(outxmin,outxmax,stampxmin,stampxmax)
-        #print(outymin,outymax,stampymin,stampymax)
-        #outcoords = np.array([outxmin,outxmax,outymin,outymax])
-#       # outputframe[0,yframessub[0]-substamplen[0]/2:yframessub[0]+substamplen[0]/2,xframessub[0]-substamplen[1]/2:xframessub[0]+substamplen[1]/2] += substamp
-
-        ##if any of the coordinates are set to NaN, then the stamp image is completely off
-        ##the output frame and it shouldn't be added
-        #if np.all(np.isfinite(outcoords)):
-        #    outputframe[0,outymin:outymax,outxmin,outxmax] += substamp[stampymin:stampymax,stampxmin,stampxmax]
-
-        
         for i in range(1,numframes+1):
-            #for frames after the 0th, start with the previous frame
-            #if i != 0:
-                #outputframe[i-1,:,:] = np.copy(outputframe[i-2,:,:])
-
-            #print("Working on frame number: {}".format(i-1))
-
-            #find the velocity of the source during this frame
-            xvelocity = (xframes[i]-xframes[i-1]) / frametime
-            yvelocity = (yframes[i]-yframes[i-1]) / frametime
+            # Find the velocity of the source during this frame
+            xvelocity = (xframes[i] - xframes[i-1]) / frametime
+            yvelocity = (yframes[i] - yframes[i-1]) / frametime
             secPerPix = 1. / np.sqrt(xvelocity*xvelocity + yvelocity*yvelocity)
-            #print('velocities:',xvelocity,yvelocity,secPerPix)
-            
-            #print("Trying to calculate xs, xssub separate for each frame! Check for correctness!!!!")
-            #xs, ys = self.equidistantXY(xframes[i-1],yframes[i-1],xframes[1],yframes[1],1./self.subsampx)
-            #xssub = np.round((xs-mnx) * self.subsampx) + deltacenterx
-            #yssub = np.round((ys-mnx) * self.subsampy) + deltacentery
-
             outputframe1 = np.copy(outputframe0)
-            
-            #print('LIMITS TO FIND STEPS: {}, {}'.format(xframessub[i-1],xframessub[i]))
-            #print(yssub,yframessub[i-1],yframessub[i])
+
             if xframessub[i-1] < xframessub[i]:
                 goodxs = ((xssub > (xframessub[i-1]+1e-7)) & (xssub < (xframessub[i]-1e-7)))
             else:
@@ -190,164 +158,114 @@ class MovingTarget():
             else:
                 good = goodys
 
-            #print('goodxs:',xssub[good])
-            #print('goodys:',yssub[good])
-
-            #print("making frame:")
-            #print(xframessub[i-1:i+1],yframessub[i-1:i+1],xssub[good],yssub[good],secPerPix)
-
-            #outputframe[i-1,:,:] = self.inputMotion(outputframe[i-1,:,:],substamp,xframessub[i-1:i+1],yframessub[i-1:i+1],xssub[good],yssub[good],secPerPix)
-
-            #print("  ")
-            #print('xstart xend, ystart, yend, xmidpts, ymidpts')
-            #print(xframessub[i-1:i+1],yframessub[i-1:i+1],xssub[good],yssub[good])
-            #print("  ")
-
-            #goodones = xssub[good]
-            #print(xframessub[i-1],goodones[0])
-            #if xframessub[i-1] > goodones[0]:
-            #    print("frame limit is greater.")
-            #elif xframessub[i-1] < goodones[0]:
-            #    print("xssub is greater")
-            #elif xframessub[i-1] == goodones[0]:
-            #    print('they are equal')
-
-            #print('Going into inputMotion:')
-            #print('outputframe1 shape',outputframe1.shape)
-            #print('subsampled stamp shape',substamp.shape)
-            #print('source location: x: {} to {}, y: {} to {}'.format(xframessub[i-1],xframessub[i],yframessub[i-1],yframessub[i]))
-            #print('locations to use:',xssub[good],yssub[good])
-
-            #if (np.all((xframessub[i-1:i+1]-substamplen[1]) > outsubshape[1]) or (np.all((yframessub[i-1:i+1]-substamplen[0]) > outsubshape[0]))):
-            #    print(xframessub[i-1:i+1])
-            #    print(substamplen)
-            #    print(outsubshape[1])
-            #    print("For frame {}, entire stamp is left or above the fov".format(i-1))
-            #    outputframe1 = np.copy(outputframe0)
-            #elif (np.all((xframessub[i-1:i+1]+substamplen[1]) < 0) or (np.all((yframessub[i-1:i+1]+substamplen[0]) < 0))):
-            #    print(xframessub[i-1:i+1])
-            #    print(substamplen)
-            #    print("0.")
-            #    print("For frame {}, entire stamp is right or below the fov".format(i-1))
-            #    outputframe1 = np.copy(outputframe0)
-
-            if (np.all((xframes[i-1:i+1]-xstamplen) > outx) or (np.all((yframes[i-1:i+1]-ystamplen) > outy))):
-                #print(xframes[i-1:i+1])
-                #print(xstamplen)
-                #print(outx)
-                #print("For frame {}, entire stamp is left or above the fov".format(i-1))
+            if (np.all((xframes[i-1:i+1]-xstamplen) > outx) or \
+                (np.all((yframes[i-1:i+1]-ystamplen) > outy))):
                 outputframe1 = np.copy(outputframe0)
-            elif (np.all((xframes[i-1:i+1]+xstamplen) < 0) or (np.all((yframes[i-1:i+1]+ystamplen) < 0))):
-                #print(xframes[i-1:i+1])
-                #print(xstamplen)
-                #print("0.")
-                #print("For frame {}, entire stamp is right or below the fov".format(i-1))
+            elif (np.all((xframes[i-1:i+1]+xstamplen) < 0) or \
+                  (np.all((yframes[i-1:i+1]+ystamplen) < 0))):
                 outputframe1 = np.copy(outputframe0)
             else:
-                #print(xframes[i-1:i+1])
-                #print(xstamplen)
-                #print(xframes[i-1:i+1]-xstamplen,xframes[i-1:i+1]+xstamplen)
-                #print("For frame {}, stamp is at least partially within the fov".format(i-1))
-                #print("going into inputmotion")
-                #print(xframessub[i-1:i+1],yframessub[i-1:i+1],xssub[good],yssub[good],secPerPix)
-                outputframe1 = self.inputMotion(outputframe1,substamp,xframessub[i-1:i+1],yframessub[i-1:i+1],xssub[good],yssub[good],secPerPix)
-
-                #h0 = fits.PrimaryHDU()
-                #h1 = fits.ImageHDU(outputframe1)
-                #hl = fits.HDUList([h0,h1])
-                #oname = 'test.fits'
-                #hl.writeto(oname,clobber=True)
-                #print(mnx,mxx,mny,mxy)
-                #print(xframes)
-                #sys.exit()
-
+                outputframe1 = self.inputMotion(outputframe1, substamp, xframessub[i-1:i+1],
+                                                yframessub[i-1:i+1],xssub[good],yssub[good],
+                                                secPerPix)
 
             outputframe0 = np.copy(outputframe1)
             
-            #oname = 'test_movingtarg_out_frame_'+str(i)+'.fits'
-            #h0 = fits.PrimaryHDU(outputframe1)
-            #hl = fits.HDUList([h0])
-            #hl.writeto(oname,clobber=True)
-
-
-            #put the output frames back to the original resolution
-            #print("miny,maxy: ",miny,maxy)
-            #print(outfull[i-1,mny:mxy+1,mnx:mxx+1].shape,test.shape)
-            #print(outputframe1.shape,test.shape)
-            #print(mnx,mxx,mny,mxy)
-            #check for sources that fall off the edges of the output array
-            #print(mny,mxy,mnx,mxx)
-
-            #print(outputframe1.shape)
-            #print(self.subsampx,self.subsampy)
-            outfull[i-1,mny:mxy+1,mnx:mxx+1] = self.resample(outputframe1,self.subsampx,self.subsampy)
-        
-        #h0 = fits.PrimaryHDU()
-        #h1 = fits.ImageHDU(outfull)
-        #hl = fits.HDUList([h0,h1])
-        #oname = 'test_movingtarg_out_frame_origres'+str(i)+'.fits'
-        #hl.writeto(oname,clobber=True)
-        #sys.exit()
-
+            # Put the output frames back to the original resolution
+            resampled = self.resample(outputframe1, self.subsampx, self.subsampy)
+            resampylen, resampxlen = resampled.shape
+            #outfull[i-1,mny:mxy+1,mnx:mxx+1] = resampled
+            maxfully = mny + resampylen
+            maxfullx = mnx + resampxlen
+            maxrey = resampylen
+            maxrex = resampxlen
+            if (mny + resampylen) > outy:
+                diffind = (mny + resampylen) - outy
+                maxfully = outy
+                maxrey -= diffind
+            if (mnx + resampxlen) > outx:
+                diffind = (mnx + resampxlen) - outx
+                maxfullx = outx
+                maxrex -= diffind
+            outfull[i-1, mny:maxfully, mnx:maxfullx] = resampled[0:maxrey, 0:maxrex]   
         return outfull
 
+    def resample(self, frame, sampx, sampy):
+        """
+        Return subsampled image back to original resolution
 
-    def resample(self,frame,sampx,sampy):
-        #return subsampled image back to original resolution
-        framey,framex = frame.shape
-        newframe = np.zeros((np.int(framey/sampy),np.int(framex/sampx)))
-        newframey,newframex = newframe.shape
+        Arguments:
+        ----------
+        frame -- subsampled image
+        sampx -- x-dimension subsampling factor (e.g. 3 means 3x oversampled
+                 compared to original image
+        sampy -- y-dimension subsampling factor
+
+        Returns:
+        --------
+        resampled image
+        """
+        framey, framex = frame.shape
+        newframe = np.zeros((np.int(framey/sampy), np.int(framex/sampx)))
+        newframey, newframex = newframe.shape
 
         for j in range(newframey):
             for i in range(newframex):
-                newframe[j,i] = np.sum(frame[sampy*j:sampy*(j+1),sampx*i:sampx*(i+1)])
+                newframe[j, i] = np.sum(frame[sampy*j:sampy*(j+1), sampx*i:sampx*(i+1)])
         return newframe
-        
 
-    def coordCheck(self,center,len_stamp,len_out):
-        # Find indexes of stamp and frame to use
-        # given that the stamp may fall off the edge
-        # of the frame
+    def coordCheck(self, center, len_stamp, len_out):
+        """
+        Find indexes of stamp and frame to use
+        given that the stamp may fall off the edge
+        of the frame. Works on only one coordinate dimension
+
+        Arguments:
+        ----------
+        center -- coordinate (in full aperture coords of the center of the 
+                  stamp image.
+        len_stamp -- Size of the stamp image
+        len_out -- Size of the full aperture image
+
+        Returns:
+        --------
+        x and y coordinates corresponding to the beginning and ending
+        (i.e. top and bottom for y-dimension, or left and right for x-
+        dimension) of the stamp image on the full frame aperture, as
+        well as the beginning and ending coordinates within the stamp 
+        image that fall onto the full frame aperture.
+        """
         outxmin = center - len_stamp/2
         outxmax = outxmin + len_stamp
         stampxmin = 0
         stampxmax = len_stamp
 
-        #print('center,len',center,len_stamp)
-        #print('before checks!!!',outxmin,outxmax,stampxmin,stampxmax)
-
-        #left edge of stamp is off the edge of output
+        # Left edge of stamp is off the edge of output
         if outxmin < 0:
-            #print('left edge of stamp is off')
             if outxmin >= (0.-len_stamp):
                 stampxmin = 0 - outxmin
                 outxmin = 0
             else:
-                #here the image is completely off the output frame
+                # Here the image is completely off the output frame
                 stampxmin = np.nan
                 outxmin = np.nan
                 stampxmax = np.nan
                 outxmax = np.nan
 
-        #right edge of stamp is off the edge of the output
+        # Right edge of stamp is off the edge of the output
         if outxmax > len_out:
-            #print('right edge of stamp is off')
-            if outxmax <= (len_out+len_stamp):
+            if outxmax <= (len_out + len_stamp):
                 delta = outxmax - len_out
                 stampxmax = len_stamp - delta
                 outxmax = len_out
             else:
-                #here the image is completely off the left side of output
+                # Here the image is completely off the left side of output
                 outxmax = np.nan
                 stampxmax = np.nan
                 outxmin = np.nan
                 stampxmin = np.nan
 
-        #print('center,len',center,len_stamp)
-        #print('after edge checks!!!',outxmin,outxmax,stampxmin,stampxmax)
-
-                
-        indexes = [outxmin,outxmax,stampxmin,stampxmax]
+        indexes = [outxmin, outxmax, stampxmin, stampxmax]
         if np.all(np.isfinite(indexes)):
             ioutxmin = np.int(outxmin)
             ioutxmax = np.int(outxmax)
@@ -355,8 +273,6 @@ class MovingTarget():
             istampxmax = np.int(stampxmax)
             dout = ioutxmax - ioutxmin
             dstamp = istampxmax - istampxmin
-            #print('before fix!!!',ioutxmin,ioutxmax,istampxmin,istampxmax)
-            #print(dout,dstamp)
 
             if dout == dstamp:
                 pass
@@ -373,132 +289,168 @@ class MovingTarget():
             else:
                 print("WARNING: bad stamp/output match. Quitting.")
                 sys.exit()
-
-            #print('center,len',center,len_stamp)
-            #print('after fix!!!',ioutxmin,ioutxmax,istampxmin,istampxmax)
-            #print(ioutxmax-ioutxmin,istampxmax-istampxmin)   
-            return ioutxmin,ioutxmax,istampxmin,istampxmax
+            return ioutxmin, ioutxmax, istampxmin, istampxmax
         else:
-            # if values are NaN then we can't change them to integers
-            return outxmin,outxmax,stampxmin,stampxmax
+            # If values are NaN then we can't change them to integers
+            return outxmin, outxmax, stampxmin, stampxmax
 
+    def inputMotion(self, inframe, source, xbounds, ybounds, xs, ys, secperpix):
+        """
+        Smear out the source to create an output frame image
+        given the necessary info about the source location and velocity
 
-    def inputMotion(self,inframe,source,xbounds,ybounds,xs,ys,secperpix):
-        #smear out the source to create an output frame image
-        #given the necessary info about the source location and velocity
+        Arguments:
+        ----------
+        inframe -- 2D array representing the image
+        source -- 2D stamp image containing the source
+        xbounds -- 2-element list containing the starting and ending x-dimension
+                   coordinates of the source (i.e. location corresponding to the 
+                   beginning and ending of the frame)
+        ybounds -- 2-element list containing the starting and ending y-dimension
+                   coordinates of the source
+        xs -- list of x-coordinate positions of the source
+        ys -- list of y-coordinate positions of the source
+        secperpix -- Inverse velocity of the source, in seconds per pixel
+        """
         frameylen,framexlen = inframe.shape
         srcylen,srcxlen = source.shape
-        xlist = np.append(xs,xbounds[1])
-        ylist = np.append(ys,ybounds[1])
-        xlist = np.insert(xlist,0,xbounds[0])
-        ylist = np.insert(ylist,0,ybounds[0])
-
-
-        #print('xlist',xlist)
-        #print('ylist',ylist)
+        xlist = np.append(xs, xbounds[1])
+        ylist = np.append(ys, ybounds[1])
+        xlist = np.insert(xlist, 0, xbounds[0])
+        ylist = np.insert(ylist, 0, ybounds[0])
         xlist = np.round(xlist)
         ylist = np.round(ylist)
-        #print('xlist',xlist)
-        #print('ylist',ylist)
 
         for i in range(1,len(xlist)):
-            #print('Working on location {},{}'.format(xlist[i],ylist[i]))
-            outxmin,outxmax,stampxmin,stampxmax = self.coordCheck(xlist[i],srcxlen,framexlen)
-            outymin,outymax,stampymin,stampymax = self.coordCheck(ylist[i],srcylen,frameylen)
-            #print('x',outxmin,outxmax,stampxmin,stampxmax,srcxlen,frameylen)
-            #print('y',outymin,outymax,stampymin,stampymax,srcylen,frameylen)
-
+            outxmin, outxmax, stampxmin, stampxmax = self.coordCheck(xlist[i], srcxlen, framexlen)
+            outymin, outymax, stampymin, stampymax = self.coordCheck(ylist[i], srcylen, frameylen)
             outcoords = np.array([outxmin,outxmax,outymin,outymax])
 
-            #if any of the coordinates are set to NaN, then the stamp image is completely off
-            #the output frame and it shouldn't be added
+            # If any of the coordinates are set to NaN, then the stamp image is completely off
+            # the output frame and it shouldn't be added
             if np.all(np.isfinite(outcoords)):       
-
                 dist = np.sqrt((xlist[i]-xlist[i-1])**2 + (ylist[i]-ylist[i-1])**2)
-                #print('distance is {}'.format(dist))
-                #print('x-coords',outxmin,outxmax,stampxmin,stampxmax)
-                #print('y-coords',outymin,outymax,stampymin,stampymax)
-                #inframe[ylist[i]-np.ceil(srcylen/2.):ylist[i]+np.ceil(srcylen/2.),xlist[i]-np.ceil(srcxlen/2.):xlist[i]+np.ceil(srcxlen/2.)] += (source*secperpix*dist)
-
-                #print('inframe shape',inframe[outymin:outymax,outxmin:outxmax].shape)
-                #print('source shape',source[stampymin:stampymax,stampxmin:stampxmax].shape)
-                
-                inframe[outymin:outymax,outxmin:outxmax] += (source[stampymin:stampymax,stampxmin:stampxmax]*secperpix*dist)
+                inframe[outymin:outymax, outxmin:outxmax] += (source[stampymin:stampymax, stampxmin:stampxmax]*secperpix*dist)
         return inframe
 
+    def subsample(self, image, factorx, factory):
+        """
+        Subsample the input image
 
-    def subsample(self,image,factorx,factory):
-        #subsample the input image
-        ydim,xdim = image.shape
-        substamp = np.zeros((ydim*factory,xdim*factorx))
+        Arguments:
+        ----------
+        image -- 2D image
+        factorx -- factor in the x-dimension to subsample the image
+                 (e.g. factorx=2 will break each pixel into 2 pixels
+                  in the x dimension)
+        factory -- factor in the y-dimension to subsample the image
+        
+        Setting factorx = 2, factory = 2 will break each pixel in the 
+        original image into a 2x2 grid of pixels
+
+        Returns:
+        --------
+        Subsampled image
+        """
+        ydim, xdim = image.shape
+        substamp = np.zeros((ydim*factory, xdim*factorx))
         
         for i in range(xdim):
             for j in range(ydim):
-                #substamp[j*factory:j*(factory+1),i*factorx:i*(factorx+1)] = image[j,i]
-                substamp[factory*j:factory*(j+1),factorx*i:factorx*(i+1)] = image[j,i]
-
+                substamp[factory*j:factory*(j+1), factorx*i:factorx*(i+1)] = image[j, i]
         return substamp
 
+    def equidistantXY(self,xstart, ystart, xend, yend, dist):
+        """
+        Return a list of x,y positions that are equidistant
+        between the beginning and ending positions, with 
+        a distance of dist pixels between them
 
-    def equidistantXY(self,xstart,ystart,xend,yend,dist): #,ang):
-        #return a list of x,y positions that are equidistant
-        #between the beginning and ending positions, with 
-        #a distance of dist pixels between them
+        Arguments:
+        ----------
+        xstart -- beginning x coordinate
+        ystart -- beginning y coordinate
+        xend -- ending x coordinate
+        yend -- ending y coordinate
+        dist -- distance in pixels between adjacent positions
+        """
         xlen = 0
         ylen = 0
 
         deltax = xend - xstart
         deltay = yend - ystart
-        ang = np.arctan2(deltay,deltax)
+        ang = np.arctan2(deltay, deltax)
         
         dx = np.cos(ang) * dist
         dy = np.sin(ang) * dist
 
         if dx != 0.:
-            xs = np.arange(xstart,xend+dx/2,dx)
+            xs = np.arange(xstart, xend+dx/2, dx)
             xlen = len(xs)
         else:
-            #motion parallel to y axis
+            # Motion parallel to y axis
             xs = np.array([xstart])
 
         if dy != 0:
-            ys = np.arange(ystart,yend+dy/2,dy)
+            ys = np.arange(ystart, yend+dy/2, dy)
             ylen = len(ys)
         else:
-            #motion parallel to x asis
+            # Motion parallel to x asis
             ys = np.array([ystart])
 
-        #make sure lengths agree
+        # Make sure lengths agree
         if xlen == 0:
             xs = np.zeros(ylen) + xstart
         if ylen == 0:
             ys = np.zeros(xlen) + ystart
-            
-        return xs,ys
-        
 
-    def radecPerFrame(self,ra0,dec0,ravel,decvel,time):
-        #generate a list of RA,Dec locations for all
-        #frames
+        return xs, ys 
+
+    def radecPerFrame(self, ra0, dec0, ravel, decvel, time):
+        """
+        Generate a list of RA,Dec locations for a source in
+        a series of frames
+
+        Arguments:
+        ----------
+        ra0 -- Initial RA value of source
+        dec0 -- Initial Dec value of source
+        ravel -- Velocity of source in the RA direction
+        decvel -- Velocity of source in the Dec direction
+        time -- List of times corresponding to all frames
+
+        Returns:
+        --------
+        List of RA, Dec positions corresponding to all input times
+        """
         ra = ra0 + (ravel * time)
         dec = dec0 + (decvel * time)
-        return ra,dec
+        return ra, dec
 
-    
-    def xyPerFrame(self,velocity,time,ang,x0,y0):
+    def xyPerFrame(self, velocity, time, ang, x0, y0):
+        """
+        Generate list of x,y positions for a source given an 
+        initial position, velocity, and velocity angle
 
-        #rate of movement in x and y (pix/sec)
+        Arguments:
+        ----------
+        velocity -- Velocity of source 
+        time -- List of times at which we want to find positions
+        ang -- Angle (in radians) at which source is traveling. 
+               An ang of zero corresponds to moving along the +x axis. 
+               An ang of np.pi/2 corresponds to moveing along the +y axis.
+        x0 -- Initial x coordinate of source
+        y0 -- Initial y coordinate of source
+
+        Returns:
+        --------
+        Tuple of x-list, y-list souce locations
+        """
         ratex = velocity * np.cos(ang)
         ratey = velocity * np.sin(ang)
 
-        #x,y in each frame
+        # x,y in each frame
         xs = x0 + ratex*time
         ys = y0 + ratey*time
         
         return xs,ys
-    
-
-
-
-        #return: ramp containing moving target. Also return the x,y position
-        #of the target in each frame.


### PR DESCRIPTION
Moving_targets mode now works when requesting multiple integrations!! Similarly, imaging mode where moving targets are included in the field also works with more than 1 integration. 

I also fixed a bug in the way the script was determining which moving targets do not overlap the detector.

As part of this, I added a new entry to the input yaml file resets_bet_ints lists the number of detector resets that happen between integrations within an exposure. For NIRCam this is 1 at the moment. This was done in order to get the relative timing between observations correct, which is important when there are moving targets in the field.

Finally, I chopped down galaxy stamp images such that the total stamp image contains 99.95% of the total normalized flux. The stamp images are still big (~650x650 pixels for a galaxy with a 1" half-light radius), but much smaller than they were previously (~1500x1500 pixels for the same case). This will speed up all work with galaxies, including any that happen to be moving across the field of view. 