### PR TITLE
Adjusted available modes. Tweaked yaml_generator outputs

### DIFF
--- a/nircam_simulator/scripts/apt_inputs.py
+++ b/nircam_simulator/scripts/apt_inputs.py
@@ -556,7 +556,7 @@ class AptInput:
         for exp, obs in zip(intab['exposure'], intab['obs_label']):
             match = np.where(obs == onames)[0]
             if len(match) == 0:
-                raise StandardError("No valid epoch line found for observation {} in observation table ({}).".format(obs, onames))
+                raise ValueError("No valid epoch line found for observation {} in observation table ({}).".format(obs, onames))
 
             # Match observation from observation table yaml file with observatoins
             # from  APT XML/pointing; extract the date and PAV3

--- a/nircam_simulator/scripts/catalog_seed_image.py
+++ b/nircam_simulator/scripts/catalog_seed_image.py
@@ -2662,6 +2662,12 @@ class Catalog_seed():
             raise ValueError(("WARNING: telescope tracking set to {}, but must be one "
                               "of {}.".format(self.params['Telescope']['tracking'],
                                               tracking_list)))
+
+        # Non-sidereal WFSS observations are not yet supported
+        if self.params['Telescope']['tracking'] == 'non-sidereal' and \
+           self.params['Inst']['mode'] in ['wfss','ts_wfss']:
+            raise ValueError(("WARNING: wfss observations with non-sidereal "
+                              "targets not yet supported."))
         
         # Set nframe and nskip according to the values in the
         # readout pattern definition file

--- a/nircam_simulator/scripts/obs_generator.py
+++ b/nircam_simulator/scripts/obs_generator.py
@@ -1513,15 +1513,6 @@ class Observation():
             synthetic = synthetic + dark.data[:, 0:self.params['Readout']['ngroup'], :, :]
             print("Number of pixels with exactly 0 signal in synthetic: {}".format(np.sum(synthetic==0)))
             reorder_sbandref = dark.sbAndRefpix
-        # Case below should be caught within inputChecks()
-        #else:
-        #    print("WARNING: Unable to convert input dark with a readout pattern")
-        #    print("of {}, to the requested readout pattern of {}."
-        #          .format(darkpatt, self.params['Readout']['readpatt']))
-        #    print("The readout pattern of the dark must be RAPID or match")
-        #    print("the requested output readout pattern.")
-        #    sys.exit()
-
         return synthetic, zeroframe, reorder_sbandref
 
     def maskRefPix(self, ramp, zero):

--- a/nircam_simulator/scripts/read_apt_xml.py
+++ b/nircam_simulator/scripts/read_apt_xml.py
@@ -270,7 +270,8 @@ class ReadAPTXML():
             ns = "{http://www.stsci.edu/JWST/APT/Template/NircamEngineeringImaging}"
 
         # Set parameters that are constant for all imaging obs
-        typeflag = template_name
+        #typeflag = template_name
+        typeflag = 'imaging'
         grismval = 'N/A'
         short_pupil = 'CLEAR'
 
@@ -342,7 +343,8 @@ class ReadAPTXML():
         ns = "{http://www.stsci.edu/JWST/APT/Template/WfscCommissioning}"
 
         # Set parameters that are constant for all WFSC obs
-        typeflag = template_name
+        #typeflag = template_name
+        typeflag = 'imaging'
         grismval = 'N/A'
         short_pupil = 'CLEAR'
         subarr = 'FULL'
@@ -406,7 +408,8 @@ class ReadAPTXML():
         ns = "{http://www.stsci.edu/JWST/APT/Template/WfscGlobalAlignment}"
 
         # Set parameters that are constant for all WFSC obs
-        typeflag = template_name
+        #typeflag = template_name
+        typeflag = 'imaging'
         grismval = 'N/A'
         short_pupil = 'CLEAR'
         subarr = 'FULL'
@@ -485,7 +488,8 @@ class ReadAPTXML():
         ns = "{http://www.stsci.edu/JWST/APT/Template/WfscCoarsePhasing}"
 
         # Set parameters that are constant for all WFSC obs
-        typeflag = template_name
+        #typeflag = template_name
+        typeflag = 'imaging'
         grismval = 'N/A'
         pdither = '1'
         pdithtype = 'NONE'
@@ -552,7 +556,8 @@ class ReadAPTXML():
         ns = "{http://www.stsci.edu/JWST/APT/Template/WfscFinePhasing}"
 
         # Set parameters that are constant for all WFSC obs
-        typeflag = template_name
+        #typeflag = template_name
+        typeflag = 'imaging'
         grismval = 'N/A'
         pdither = '1'
         pdithtype = 'NONE'
@@ -717,7 +722,8 @@ class ReadAPTXML():
                 self.obs_tuple_list.append(tup_to_add)
 
                 directexp = expseq.find(ns + 'DiExposure')
-                typeflag = template_name
+                #typeflag = template_name
+                typeflag = 'imaging'
                 pdither = '1'  # direct image has no dithers
                 sdither = '1'  # direct image has no dithers
                 sdithtype = '1'  # direct image has no dithers

--- a/nircam_simulator/scripts/wfss_simulator.py
+++ b/nircam_simulator/scripts/wfss_simulator.py
@@ -76,6 +76,7 @@ class WFSSSim():
         self.prepDark = None
         self.save_dispersed_seed = True
         self.disp_seed_filename = None
+        self.extrapolate_SED = False
 
     def create(self):
         # Make sure inputs are correct
@@ -97,21 +98,23 @@ class WFSSSim():
         loc = os.path.join(self.datadir,"GRISM_NIRCAM/")
         background_file = ("{}_{}_back.fits"
                            .format(self.crossing_filter,dmode))
-        disp_seed = Grism_seed(imseeds,self.crossing_filter,
-                               dmode,config_path=loc)
+        disp_seed = Grism_seed(imseeds, self.crossing_filter,
+                               dmode, config_path=loc,
+                               extrapolate_SED=self.extrapolate_SED)
         disp_seed.observation()
         disp_seed.finalize(Back = background_file)
 
         # Save the dispersed seed image
         if self.save_dispersed_seed:
+            from astropy.io import fits
             hh00 = fits.PrimaryHDU()
             hh11 = fits.ImageHDU(disp_seed.final)
             hhll = fits.HDUList([hh00,hh11])
             if self.disp_seed_filename is None:
                 pdir, pf = os.path.split(self.paramfiles[0])
-                dname = 'dispersed_seed_image_for_' + pf
+                dname = 'dispersed_seed_image_for_' + pf + '.fits'
                 self.disp_seed_filename = os.path.join(pdir, dname)
-            hhll.writeto(self.disp_seed_filename)
+            hhll.writeto(self.disp_seed_filename, overwrite=True)
             print(("Dispersed seed image saved to {}"
                    .format(self.disp_seed_filename)))
             
@@ -200,6 +203,7 @@ class WFSSSim():
         parser.add_argument("--module",help = "NIRCam module to use for simulation. Use 'A' or 'B'",default=None)
         parser.add_argument("--direction",help = "Direction of dispersion (along rows or along columns). Use 'R' or 'C'",default=None)
         parser.add_argument("--override_dark",help="If supplied, skip the dark preparation step and use the supplied dark to make the exposure", default=None)
+        parser.add_argument("--extrapolate_SED", help="If true, the SED created from the filter-averaged magnitudes will be extrapolated to fill the wavelngth range of the grism", action='store_true')
         return parser
 
 


### PR DESCRIPTION
Adjusted yaml_generator outputs so that possible output modes are 'imaging' or 'wfss'. Updated catalog_seed_generator and obs_generator such that these along with ts_imaging and ts_wfss are the only available modes. Moving target observations are now controlled by the 'tracking' entry in the yaml file. With this method, we separate the information that is used to populate the EXP_TYPE keyword and the information that controls code flow.