### PR TITLE
Updated assumption of psf filenames 

### DIFF
--- a/nircam_simulator/scripts/catalog_seed_image.py
+++ b/nircam_simulator/scripts/catalog_seed_image.py
@@ -1618,10 +1618,10 @@ class Catalog_seed():
             else:
                 bstr = str(b)[0:4]
 
-            if ((a != 0) & (astr[-1] == '0')):
-                astr = astr[0:-1]
-            if ((b != 0) & (bstr[-1] == '0')):
-                bstr = bstr[0:-1]
+            if astr == "0.0":
+                astr = "0.00"
+            if bstr == "0.0":
+                bstr = "0.00"
 
             #generate the psf file name based on the center of the point source
             #in units of fraction of a pixel
@@ -2896,7 +2896,7 @@ class Catalog_seed():
         # has the PSF centered on the pixel. This will be used
         # if there are sersic or extended sources that need to
         # be convolved with the NIRCam PSF before adding
-        centerpsffile = os.path.join(self.params['simSignals']['psfpath'], psfname + '_0p0_0p0.fits')
+        centerpsffile = os.path.join(self.params['simSignals']['psfpath'], psfname + '_0p00_0p00.fits')
         self.centerpsf = fits.getdata(centerpsffile)
         self.centerpsf = self.cropPSF(self.centerpsf)
 


### PR DESCRIPTION
Previously PSF filenames had variable number of significant figures in the pixel fraction values. 

e.g. nircam_A1_x1024_y1024_f090w_predicted_0_0p5_0p25.fits

To simplify things, this update now assumes 2 significant figures in all cases. 

e.g. nircam_A1_x1024_y1024_f090w_predicted_0_0p50_0p25.fits

This was also done in preparing to support NIRISS and FGS, which will have their own PSF libraries.