### PR TITLE
NIRISS APT interface

### DIFF
--- a/nircam_simulator/config/niriss_dual_wheel_list.txt
+++ b/nircam_simulator/config/niriss_dual_wheel_list.txt
@@ -1,6 +1,6 @@
 filter  filter_wheel  pupil_wheel
 F090W      CLEAR         F090W
-F115W      CLeaR         F115W
+F115W      CLEAR         F115W
 F140M      CLEAR         F140M
 F150W      CLEAR         F150W
 F159M      CLEAR         F159M

--- a/nircam_simulator/scripts/apt_inputs.py
+++ b/nircam_simulator/scripts/apt_inputs.py
@@ -113,8 +113,8 @@ class AptInput:
         # Expand for detectors. Create one entry in each list for each
         # detector, rather than a single entry for 'ALL' or 'BSALL'
 
-        if np.all([True for j in obstab['Module'] if j is None]):
-            # skip step if NIRCam is not used
+        # test if Module is always 'None', i.e. when NIRCam is not used
+        if obstab['Module'].count('None') == len(obstab['Module']):
             self.exposure_tab = obstab
         else:
             self.exposure_tab = self.expand_for_detectors(obstab)

--- a/nircam_simulator/scripts/apt_inputs.py
+++ b/nircam_simulator/scripts/apt_inputs.py
@@ -680,7 +680,7 @@ class AptInput:
                     #     value = 'None'
 
                     intab[key].append(value)
-
+        
         return intab
 
     def add_epochs(self, intab):

--- a/nircam_simulator/scripts/apt_inputs.py
+++ b/nircam_simulator/scripts/apt_inputs.py
@@ -95,7 +95,11 @@ class AptInput:
         # Expand the dictionary for multiple dithers. Expand such that there
         # is one entry in each list for each exposure, rather than one entry
         # for each set of dithers
-        xmltab = self.expand_for_dithers(tab)
+        if np.all(np.array(tab['PrimaryDithers']).astype(int) == 1):
+            # skip step if no dithers are included
+            xmltab = tab
+        else:
+            xmltab = self.expand_for_dithers(tab)
 
         # Read in the pointing file and produce dictionary
         pointing_tab = self.get_pointing_info(self.pointing_file, xmltab['ProposalID'][0])
@@ -108,7 +112,12 @@ class AptInput:
 
         # Expand for detectors. Create one entry in each list for each
         # detector, rather than a single entry for 'ALL' or 'BSALL'
-        self.exposure_tab = self.expand_for_detectors(obstab)
+
+        if np.all([True for j in obstab['Module'] if j is None]):
+            # skip step if NIRCam is not used
+            self.exposure_tab = obstab
+        else:
+            self.exposure_tab = self.expand_for_detectors(obstab)
 
         detectors_file = os.path.join(main_dir, 'expand_for_detectors.csv')
         ascii.write(Table(self.exposure_tab), detectors_file, format='csv', overwrite=True)
@@ -282,7 +291,8 @@ class AptInput:
                         # (that I've seen so far)
                         #
                         # Also, skip non-NIRCam lines. Check for NRC in aperture name
-                        if ((np.int(elements[1]) > 0) & ('NRC' in elements[4])):
+                        # Add NIRISS support (JSA)
+                        if ((np.int(elements[1]) > 0) & ('NRC' in elements[4] or 'NIS' in elements[4])):
                             if skip:
                                 act_counter += 1
                                 continue
@@ -419,12 +429,16 @@ class AptInput:
             # to calculate ra, dec at each detector's reference location
             scripts_path = os.path.dirname(os.path.realpath(__file__))
             modpath = os.path.split(scripts_path)[0]
-            subarray_def_file = os.path.join(modpath, 'config', 'NIRCam_subarray_definitions.list')
+            if self.exposure_tab['Instrument'][i].lower() == 'nircam':
+                subarray_def_file = os.path.join(modpath, 'config', 'NIRCam_subarray_definitions.list')
+                detector = 'NRC' + self.exposure_tab['detector'][i]
+                sub = self.exposure_tab['Subarray'][i]
+                aperture = detector + '_' + sub
+            elif self.exposure_tab['Instrument'][i].lower() == 'niriss':
+                subarray_def_file = os.path.join(modpath, 'config', 'niriss_subarrays.list')
+                aperture = self.exposure_tab['aperture'][i]
 
             config = ascii.read(subarray_def_file)
-            detector = 'NRC' + self.exposure_tab['detector'][i]
-            sub = self.exposure_tab['Subarray'][i]
-            aperture = detector + '_' + sub
             if aperture in config['AperName']:
                 pass
             else:
@@ -442,7 +456,11 @@ class AptInput:
             pointing_dec = np.float(self.exposure_tab['dec'][i])
             pointing_v2 = np.float(self.exposure_tab['v2'][i])
             pointing_v3 = np.float(self.exposure_tab['v3'][i])
-            pav3 = np.float(self.exposure_tab['pav3'][i])
+
+            if 'pav3' in self.exposure_tab.keys():
+                pav3 = np.float(self.exposure_tab['pav3'][i])
+            else:
+                pav3 = np.float(self.exposure_tab['PAV3'][i])
 
             # calculate local roll angle
             local_roll = set_telescope_pointing.compute_local_roll(pav3, pointing_ra,
@@ -512,128 +530,157 @@ class AptInput:
             onums.append(observation)
         onames = np.array(onames)
 
-        obs_start = []
-        obs_pav3 = []
-        obs_sw_ptsrc = []
-        obs_sw_galcat = []
-        obs_sw_ext = []
-        obs_sw_extscl = []
-        obs_sw_extcent = []
-        obs_sw_movptsrc = []
-        obs_sw_movgal = []
-        obs_sw_movext = []
-        obs_sw_movconv = []
-        obs_sw_solarsys = []
-        obs_sw_bkgd = []
-        obs_lw_ptsrc = []
-        obs_lw_galcat = []
-        obs_lw_ext = []
-        obs_lw_extscl = []
-        obs_lw_extcent = []
-        obs_lw_movptsrc = []
-        obs_lw_movgal = []
-        obs_lw_movext = []
-        obs_lw_movconv = []
-        obs_lw_solarsys = []
-        obs_lw_bkgd = []
 
-        # This will allow the filter values
-        # in the observation table to override
-        # what comes from APT. This is useful for
-        # WFSS observations, where you want to create
-        # 'direct images' in various filters to hand
-        # to the disperser software in order to create
-        # simulated dispersed data. In that case, you
-        # would need to create 'direct images' using
-        # several filters inside the filter listed in APT
-        # in order to get broadband colors to disperse.
-        # If filter names are present in the observation
-        # yaml file, then they will be used. If not, the
-        # filters from APT will be kept
-        obs_sw_filt = []
-        obs_lw_filt = []
+        OBSERVATION_LIST_FIELDS = 'Name Date PAV3 Filter PointSourceCatalog GalaxyCatalog ExtendedCatalog ExtendedScale ExtendedCenter MovingTargetList MovingTargetSersic MovingTargetExtended MovingTargetConvolveExtended MovingTargetToTrack BackgroundRate'.split()
 
-        for exp, obs in zip(intab['exposure'], intab['obs_label']):
-            match = np.where(obs == onames)[0]
-            if len(match) == 0:
-                raise ValueError("No valid epoch line found for observation {} in observation table ({}).".format(obs, onames))
+        if np.unique(intab['Instrument'])[0].lower() == 'nircam':
 
-            # Match observation from observation table yaml file with observatoins
-            # from  APT XML/pointing; extract the date and PAV3
-            obslist = self.obstab[onums[match[0]]]
-            obs_start.append(obslist['Date'].strftime('%Y-%m-%d'))
-            obs_pav3.append(obslist['PAV3'])
+            obs_start = []
+            obs_pav3 = []
+            obs_sw_ptsrc = []
+            obs_sw_galcat = []
+            obs_sw_ext = []
+            obs_sw_extscl = []
+            obs_sw_extcent = []
+            obs_sw_movptsrc = []
+            obs_sw_movgal = []
+            obs_sw_movext = []
+            obs_sw_movconv = []
+            obs_sw_solarsys = []
+            obs_sw_bkgd = []
+            obs_lw_ptsrc = []
+            obs_lw_galcat = []
+            obs_lw_ext = []
+            obs_lw_extscl = []
+            obs_lw_extcent = []
+            obs_lw_movptsrc = []
+            obs_lw_movgal = []
+            obs_lw_movext = []
+            obs_lw_movconv = []
+            obs_lw_solarsys = []
+            obs_lw_bkgd = []
 
-            # Then, match up with the filter configuration using the exposure
-            # number
-            exposure = int(exp[-2:])
-            filter_config = 'FilterConfig{}'.format(exposure)
-            obslist = obslist[filter_config]
+            # This will allow the filter values
+            # in the observation table to override
+            # what comes from APT. This is useful for
+            # WFSS observations, where you want to create
+            # 'direct images' in various filters to hand
+            # to the disperser software in order to create
+            # simulated dispersed data. In that case, you
+            # would need to create 'direct images' using
+            # several filters inside the filter listed in APT
+            # in order to get broadband colors to disperse.
+            # If filter names are present in the observation
+            # yaml file, then they will be used. If not, the
+            # filters from APT will be kept
+            obs_sw_filt = []
+            obs_lw_filt = []
 
-            obs_sw_ptsrc.append(obslist['SW']['PointSourceCatalog'])
-            obs_sw_galcat.append(obslist['SW']['GalaxyCatalog'])
-            obs_sw_ext.append(obslist['SW']['ExtendedCatalog'])
-            obs_sw_extscl.append(obslist['SW']['ExtendedScale'])
-            obs_sw_extcent.append(obslist['SW']['ExtendedCenter'])
-            obs_sw_movptsrc.append(obslist['SW']['MovingTargetList'])
-            obs_sw_movgal.append(obslist['SW']['MovingTargetSersic'])
-            obs_sw_movext.append(obslist['SW']['MovingTargetExtended'])
-            obs_sw_movconv.append(obslist['SW']['MovingTargetConvolveExtended'])
-            obs_sw_solarsys.append(obslist['SW']['MovingTargetToTrack'])
-            obs_sw_bkgd.append(obslist['SW']['BackgroundRate'])
-            obs_lw_ptsrc.append(obslist['LW']['PointSourceCatalog'])
-            obs_lw_galcat.append(obslist['LW']['GalaxyCatalog'])
-            obs_lw_ext.append(obslist['LW']['ExtendedCatalog'])
-            obs_lw_extscl.append(obslist['LW']['ExtendedScale'])
-            obs_lw_extcent.append(obslist['LW']['ExtendedCenter'])
-            obs_lw_movptsrc.append(obslist['LW']['MovingTargetList'])
-            obs_lw_movgal.append(obslist['LW']['MovingTargetSersic'])
-            obs_lw_movext.append(obslist['LW']['MovingTargetExtended'])
-            obs_lw_movconv.append(obslist['LW']['MovingTargetConvolveExtended'])
-            obs_lw_solarsys.append(obslist['LW']['MovingTargetToTrack'])
-            obs_lw_bkgd.append(obslist['LW']['BackgroundRate'])
+            for exp, obs in zip(intab['exposure'], intab['obs_label']):
+                match = np.where(obs == onames)[0]
+                if len(match) == 0:
+                    raise ValueError("No valid epoch line found for observation {} in observation table ({}).".format(obs, onames))
 
-            # Override filters if given
-            try:
-                obs_sw_filt.append(obslist['SW']['Filter'])
-            except:
-                pass
-            try:
-                obs_lw_filt.append(obslist['LW']['Filter'])
-            except:
-                pass
+                # Match observation from observation table yaml file with observatoins
+                # from  APT XML/pointing; extract the date and PAV3
+                obslist = self.obstab[onums[match[0]]]
+                obs_start.append(obslist['Date'].strftime('%Y-%m-%d'))
+                obs_pav3.append(obslist['PAV3'])
 
-        intab['epoch_start_date'] = obs_start
-        intab['pav3'] = obs_pav3
-        intab['sw_ptsrc'] = obs_sw_ptsrc
-        intab['sw_galcat'] = obs_sw_galcat
-        intab['sw_ext'] = obs_sw_ext
-        intab['sw_extscl'] = obs_sw_extscl
-        intab['sw_extcent'] = obs_sw_extcent
-        intab['sw_movptsrc'] = obs_sw_movptsrc
-        intab['sw_movgal'] = obs_sw_movgal
-        intab['sw_movext'] = obs_sw_movext
-        intab['sw_movconv'] = obs_sw_movconv
-        intab['sw_solarsys'] = obs_sw_solarsys
-        intab['sw_bkgd'] = obs_sw_bkgd
-        intab['lw_ptsrc'] = obs_lw_ptsrc
-        intab['lw_galcat'] = obs_lw_galcat
-        intab['lw_ext'] = obs_lw_ext
-        intab['lw_extscl'] = obs_lw_extscl
-        intab['lw_extcent'] = obs_lw_extcent
-        intab['lw_movptsrc'] = obs_lw_movptsrc
-        intab['lw_movgal'] = obs_lw_movgal
-        intab['lw_movext'] = obs_lw_movext
-        intab['lw_movconv'] = obs_lw_movconv
-        intab['lw_solarsys'] = obs_lw_solarsys
-        intab['lw_bkgd'] = obs_lw_bkgd
+                # Then, match up with the filter configuration using the exposure
+                # number
+                exposure = int(exp[-2:])
+                filter_config = 'FilterConfig{}'.format(exposure)
+                obslist = obslist[filter_config]
 
-        # Here we override the filters read from APT
-        # if they are given in the observation yaml file
-        if len(obs_sw_filt) > 0:
-            intab['ShortFilter'] = obs_sw_filt
-        if len(obs_lw_filt) > 0:
-            intab['LongFilter'] = obs_lw_filt
+                obs_sw_ptsrc.append(obslist['SW']['PointSourceCatalog'])
+                obs_sw_galcat.append(obslist['SW']['GalaxyCatalog'])
+                obs_sw_ext.append(obslist['SW']['ExtendedCatalog'])
+                obs_sw_extscl.append(obslist['SW']['ExtendedScale'])
+                obs_sw_extcent.append(obslist['SW']['ExtendedCenter'])
+                obs_sw_movptsrc.append(obslist['SW']['MovingTargetList'])
+                obs_sw_movgal.append(obslist['SW']['MovingTargetSersic'])
+                obs_sw_movext.append(obslist['SW']['MovingTargetExtended'])
+                obs_sw_movconv.append(obslist['SW']['MovingTargetConvolveExtended'])
+                obs_sw_solarsys.append(obslist['SW']['MovingTargetToTrack'])
+                obs_sw_bkgd.append(obslist['SW']['BackgroundRate'])
+                obs_lw_ptsrc.append(obslist['LW']['PointSourceCatalog'])
+                obs_lw_galcat.append(obslist['LW']['GalaxyCatalog'])
+                obs_lw_ext.append(obslist['LW']['ExtendedCatalog'])
+                obs_lw_extscl.append(obslist['LW']['ExtendedScale'])
+                obs_lw_extcent.append(obslist['LW']['ExtendedCenter'])
+                obs_lw_movptsrc.append(obslist['LW']['MovingTargetList'])
+                obs_lw_movgal.append(obslist['LW']['MovingTargetSersic'])
+                obs_lw_movext.append(obslist['LW']['MovingTargetExtended'])
+                obs_lw_movconv.append(obslist['LW']['MovingTargetConvolveExtended'])
+                obs_lw_solarsys.append(obslist['LW']['MovingTargetToTrack'])
+                obs_lw_bkgd.append(obslist['LW']['BackgroundRate'])
+
+                # Override filters if given
+                try:
+                    obs_sw_filt.append(obslist['SW']['Filter'])
+                except:
+                    pass
+                try:
+                    obs_lw_filt.append(obslist['LW']['Filter'])
+                except:
+                    pass
+
+            intab['epoch_start_date'] = obs_start
+            intab['pav3'] = obs_pav3
+            intab['sw_ptsrc'] = obs_sw_ptsrc
+            intab['sw_galcat'] = obs_sw_galcat
+            intab['sw_ext'] = obs_sw_ext
+            intab['sw_extscl'] = obs_sw_extscl
+            intab['sw_extcent'] = obs_sw_extcent
+            intab['sw_movptsrc'] = obs_sw_movptsrc
+            intab['sw_movgal'] = obs_sw_movgal
+            intab['sw_movext'] = obs_sw_movext
+            intab['sw_movconv'] = obs_sw_movconv
+            intab['sw_solarsys'] = obs_sw_solarsys
+            intab['sw_bkgd'] = obs_sw_bkgd
+            intab['lw_ptsrc'] = obs_lw_ptsrc
+            intab['lw_galcat'] = obs_lw_galcat
+            intab['lw_ext'] = obs_lw_ext
+            intab['lw_extscl'] = obs_lw_extscl
+            intab['lw_extcent'] = obs_lw_extcent
+            intab['lw_movptsrc'] = obs_lw_movptsrc
+            intab['lw_movgal'] = obs_lw_movgal
+            intab['lw_movext'] = obs_lw_movext
+            intab['lw_movconv'] = obs_lw_movconv
+            intab['lw_solarsys'] = obs_lw_solarsys
+            intab['lw_bkgd'] = obs_lw_bkgd
+
+            # Here we override the filters read from APT
+            # if they are given in the observation yaml file
+            if len(obs_sw_filt) > 0:
+                intab['ShortFilter'] = obs_sw_filt
+            if len(obs_lw_filt) > 0:
+                intab['LongFilter'] = obs_lw_filt
+
+        # NIRISS case
+        elif np.unique(intab['Instrument'])[0].lower() == 'niriss':
+            for key in OBSERVATION_LIST_FIELDS:
+                intab[key] = []
+
+            for exp, obs in zip(intab['exposure'], intab['obs_label']):
+                match = np.where(obs == onames)[0]
+                if len(match) == 0:
+                    raise ValueError("No valid epoch line found for observation {} in observation table ({}).".format(obs, onames))
+
+                # Match observation from observation table yaml file with observatoins
+                # from  APT XML/pointing; extract the date and PAV3
+                obslist = self.obstab[onums[match[0]]]
+                for key in OBSERVATION_LIST_FIELDS:
+                    if key == 'Date':
+                        value = obslist[key].strftime('%Y-%m-%d')
+                    else:
+                        value = str(obslist[key])
+                    # if value is None:
+                    #     value = 'None'
+
+                    intab[key].append(value)
+
         return intab
 
     def add_epochs(self, intab):

--- a/nircam_simulator/scripts/catalog_seed_image.py
+++ b/nircam_simulator/scripts/catalog_seed_image.py
@@ -1637,6 +1637,10 @@ class Catalog_seed():
             if bstr == "0.0":
                 bstr = "0.00"
 
+            if self.params['simSignals']['psfbasename'].lower() == 'niriss':
+                astr = '{:1.2f}'.format(np.float(astr))
+                bstr = '{:1.2f}'.format(np.float(bstr))
+
             #generate the psf file name based on the center of the point source
             #in units of fraction of a pixel
             frag = astr + '_' + bstr
@@ -1659,8 +1663,7 @@ class Catalog_seed():
                     else:
                         raise FileNotFoundError("PSF file {} not found.".format(psffn))
                 except:
-                    print("ERROR: Could not load PSF file {} from library".format(psffn))
-                    sys.exit()
+                    raise RuntimeError("ERROR: Could not load PSF file {} from library".format(psffn))
 
             # Normalize the total signal in the PSF as read in
             totalsignal = np.sum(webbpsfimage)

--- a/nircam_simulator/scripts/obs_generator.py
+++ b/nircam_simulator/scripts/obs_generator.py
@@ -99,7 +99,11 @@ class Observation():
         self.slowaxis = self.linDark.header['SLOWAXIS']
 
         # Get detector/channel specific values
-        self.channel_specific_dicts()
+        if self.instrument.lower() == 'nircam':
+            self.channel_specific_dicts()
+        elif self.instrument.lower() == 'niriss':
+            # pixel scales should be read from SIAF (?)
+            self.pixscale = [0.064746, 0.064746]
 
         # Get the input seed image if a filename is supplied
         if type(self.seed) == type('string'):
@@ -970,7 +974,7 @@ class Observation():
             fwpw['pupil_wheel'] = self.params['Readout']['pupil']
 
         #get the proper filter wheel and pupil wheel values for the header
-        if self.params['Inst']['mode'].lower() not in ['wfss','ts_wfss']:
+        if (self.params['Inst']['instrument'].lower() == 'nircam') and (self.params['Inst']['mode'].lower() not in ['wfss','ts_wfss']):
             mtch = fwpw['filter'] == self.params['Readout']['filter'].upper()
             fw = str(fwpw['filter_wheel'].data[mtch][0])
             pw = str(fwpw['pupil_wheel'].data[mtch][0])
@@ -982,8 +986,7 @@ class Observation():
 
         outModel.meta.instrument.filter = fw
         outModel.meta.instrument.pupil = pw
-
-        outModel.meta.dither.primary_type = self.params['Output']['primary_dither_type']
+        outModel.meta.dither.primary_type = self.params['Output']['primary_dither_type'].upper()
         outModel.meta.dither.position_number = self.params['Output']['primary_dither_position']
         outModel.meta.dither.total_points = self.params['Output']['total_primary_dither_positions']
         outModel.meta.dither.pattern_size = 0.0

--- a/nircam_simulator/scripts/read_apt_xml.py
+++ b/nircam_simulator/scripts/read_apt_xml.py
@@ -265,17 +265,21 @@ class ReadAPTXML():
         dictionary['ObservationID'].append(tup[21])
         dictionary['TileNumber'].append(tup[22])
         dictionary['APTTemplate'].append(tup[23])
+        dictionary['Instrument'].append(tup[24])
         return dictionary
 
 
     def read_generic_imaging_template(self, template, template_name, obs, proposal_parameter_dictionary):
-        """Read imaging template content regardless of instrument.
+        """Read imaging template content regardless of instrument. 
+        Save content to object attributes.
 
-        :param template:
-        :param template_name:
-        :param obs:
-        :param proposal_parameter_dictionary: dict
-        :return:
+        Parameters
+        ----------
+        template
+        template_name : str
+        obs
+        proposal_parameter_dictionary : dict
+
         """
 
         instrument = obs.find(self.apt + 'Instrument').text
@@ -287,7 +291,6 @@ class ReadAPTXML():
 
         for key in self.APTObservationParams_keys:
             exposures_dictionary[key] = []
-        # exposures_dictionary['Instrument'] = []
 
         # Set namespace
         ns = "{{http://www.stsci.edu/JWST/APT/Template/{}}}".format(template_name)
@@ -339,10 +342,9 @@ class ReadAPTXML():
 
         self.APTObservationParams = exposures_dictionary
 
-        print(exposures_dictionary)
+        # print(exposures_dictionary)
         return
 
-        # self.obs_tuple_list.append(tup_to_add)
 
 
     def read_imaging_template(self, template, template_name, obs, prop_params):
@@ -356,6 +358,8 @@ class ReadAPTXML():
         #     ns = "{http://www.stsci.edu/JWST/APT/Template/NircamImaging}"
         # elif template_name == 'NircamEngineeringImaging':
         #     ns = "{http://www.stsci.edu/JWST/APT/Template/NircamEngineeringImaging}"
+
+        instrument = obs.find(self.apt + 'Instrument').text
 
         # Set parameters that are constant for all imaging obs
         #typeflag = template_name
@@ -419,7 +423,7 @@ class ReadAPTXML():
                           pdither, sdithtype, sdither, sfilt, lfilt,
                           rpatt, grps, ints, short_pupil,
                           long_pupil, grismval, coordparallel,
-                          i_obs + 1, 1, template_name)
+                          i_obs + 1, 1, template_name, instrument)
             self.APTObservationParams = self.add_exposure(self.APTObservationParams, tup_to_add)
             self.obs_tuple_list.append(tup_to_add)
 

--- a/nircam_simulator/scripts/read_apt_xml.py
+++ b/nircam_simulator/scripts/read_apt_xml.py
@@ -4,6 +4,7 @@ import re
 from lxml import etree
 from astropy.io import ascii
 import numpy as np
+from collections import OrderedDict
 import pprint
 
 class ReadAPTXML():
@@ -31,7 +32,7 @@ class ReadAPTXML():
         # Set up dictionary of observation parameters to be populated
         ProposalParams_keys = ['PI_Name', 'Proposal_category', 'ProposalID',
                                'Science_category', 'Title']
-        ObsParams_keys = ['Module', 'Subarray',
+        ObsParams_keys = ['Module', 'Subarray', 'Instrument',
                           'PrimaryDitherType', 'PrimaryDithers', 'SubpixelPositions',
                           'SubpixelDitherType', 'CoordinatedParallel',
                           'ObservationID', 'TileNumber', 'APTTemplate']
@@ -39,10 +40,10 @@ class ReadAPTXML():
                              'ReadoutPattern', 'Groups', 'Integrations']
         OtherParams_keys = ['Mode', 'Grism']
 
-        APTObservationParams_keys = ProposalParams_keys + ObsParams_keys + \
+        self.APTObservationParams_keys = ProposalParams_keys + ObsParams_keys + \
             FilterParams_keys + OtherParams_keys
         self.APTObservationParams = {}
-        for key in APTObservationParams_keys:
+        for key in self.APTObservationParams_keys:
             self.APTObservationParams[key] = []
 
     def read_xml(self, infile):
@@ -126,7 +127,7 @@ class ReadAPTXML():
         i_observations = []
         obs_indices = range(len(obs_results))
         for o, i_obs in zip(obs_results, obs_indices):
-            if o.find(self.apt + 'Instrument').text in ['NIRCAM', 'WFSC']:
+            if o.find(self.apt + 'Instrument').text in ['NIRCAM', 'WFSC', 'NIRISS']:
                 observations.append(o)
                 i_observations.append(i_obs)
 
@@ -144,7 +145,8 @@ class ReadAPTXML():
             # Are all the templates in the XML file something that we can handle?
             known_APT_templates = ['NircamImaging', 'NircamWfss', 'WfscCommissioning',
                                    'NircamEngineeringImaging', 'WfscGlobalAlignment',
-                                   'WfscCoarsePhasing', 'WfscFinePhasing']
+                                   'WfscCoarsePhasing', 'WfscFinePhasing',
+                                   'NirissExternalCalibration']
             if template_name not in known_APT_templates:
                 # If not, turn back now.
                 raise ValueError('No protocol written to read {} template.'.format(template_name))
@@ -176,10 +178,16 @@ class ReadAPTXML():
             prop_params = [pi_name, prop_id, prop_title, prop_category,
                            science_category, coordparallel, i_obs]
 
+            proposal_parameter_dictionary = {'PI_Name': pi_name, 'ProposalID': prop_id, 'Title': prop_title, 'Proposal_category': prop_category, 'Science_category': science_category, 'CoordinatedParallel': coordparallel, 'ObservationID': i_obs}
+
+
             # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
             # If template is NircamImaging or NircamEngineeringImaging
             if template_name in ['NircamImaging', 'NircamEngineeringImaging']:
                 self.read_imaging_template(template, template_name, obs, prop_params)
+
+            elif template_name in ['NirissExternalCalibration']:
+                self.read_generic_imaging_template(template, template_name, obs, proposal_parameter_dictionary)
 
             # If template is WFSC Commissioning
             if template_name in ['WfscCommissioning']:
@@ -259,15 +267,91 @@ class ReadAPTXML():
         dictionary['APTTemplate'].append(tup[23])
         return dictionary
 
+
+    def read_generic_imaging_template(self, template, template_name, obs, proposal_parameter_dictionary):
+        """Read imaging template content regardless of instrument.
+
+        :param template:
+        :param template_name:
+        :param obs:
+        :param proposal_parameter_dictionary: dict
+        :return:
+        """
+
+        instrument = obs.find(self.apt + 'Instrument').text
+
+        # Get proposal parameters
+        # pi_name, prop_id, prop_title, prop_category, science_category, coordparallel, i_obs = prop_params
+
+        exposures_dictionary = OrderedDict()
+
+        for key in self.APTObservationParams_keys:
+            exposures_dictionary[key] = []
+        # exposures_dictionary['Instrument'] = []
+
+        # Set namespace
+        ns = "{{http://www.stsci.edu/JWST/APT/Template/{}}}".format(template_name)
+
+        for element in template:
+            element_tag_stripped = element.tag.split(ns)[1]
+            print('{} {}'.format(element_tag_stripped, element.text))
+
+            # for NIRISS loop through exposures and collect exposure parameters
+            if (instrument.lower()=='niriss') and (element_tag_stripped == 'ExposureList'):
+                for exposure in element.findall(ns + 'Exposure'):
+                    exposure_dict = {}
+                    for exposure_parameter in exposure:
+                        parameter_tag_stripped = exposure_parameter.tag.split(ns)[1]
+                        print('{} {}'.format(parameter_tag_stripped, exposure_parameter.text))
+                        exposure_dict[parameter_tag_stripped] = exposure_parameter.text
+
+                    # fill dictionary to return
+                    for key in self.APTObservationParams_keys:
+                        if key in exposure_dict.keys():
+                            value = exposure_dict[key]
+                            print(key)
+                        elif key in proposal_parameter_dictionary.keys():
+                            value = proposal_parameter_dictionary[key]
+                            print(key)
+                        elif key == 'Instrument':
+                            value = instrument
+                        else:
+                            value = str(None)
+
+                        if (key == 'PrimaryDithers') and ((value is None) or (value == 'None')):
+                            value = '1'
+
+                        exposures_dictionary[key].append(value)
+
+                    # add keys that were not defined in self.APTObservationParams_keys
+                    # (to be fixed in Class.__init__ later )
+                    for key in exposure_dict.keys():
+                        if key not in self.APTObservationParams_keys:
+                            # if key not yet present, create entry
+                            if key not in exposures_dictionary.keys():
+                                exposures_dictionary[key] = [str(exposure_dict[key])]
+                            else:
+                                exposures_dictionary[key].append(str(exposure_dict[key]))
+
+        self.APTObservationParams = exposures_dictionary
+
+        print(exposures_dictionary)
+        return
+
+        # self.obs_tuple_list.append(tup_to_add)
+
+
     def read_imaging_template(self, template, template_name, obs, prop_params):
         # Get proposal parameters
         pi_name, prop_id, prop_title, prop_category, science_category, coordparallel, i_obs = prop_params
 
+
         # Set namespace
-        if template_name == 'NircamImaging':
-            ns = "{http://www.stsci.edu/JWST/APT/Template/NircamImaging}"
-        elif template_name == 'NircamEngineeringImaging':
-            ns = "{http://www.stsci.edu/JWST/APT/Template/NircamEngineeringImaging}"
+        ns = "{{http://www.stsci.edu/JWST/APT/Template/{}}}".format(template_name)
+        # if template_name == 'NircamImaging':
+        #     ns = "{http://www.stsci.edu/JWST/APT/Template/NircamImaging}"
+        # elif template_name == 'NircamEngineeringImaging':
+        #     ns = "{http://www.stsci.edu/JWST/APT/Template/NircamEngineeringImaging}"
 
         # Set parameters that are constant for all imaging obs
         #typeflag = template_name

--- a/nircam_simulator/scripts/read_apt_xml.py
+++ b/nircam_simulator/scripts/read_apt_xml.py
@@ -321,6 +321,10 @@ class ReadAPTXML():
                         if (key == 'PrimaryDithers') and ((value is None) or (value == 'None')):
                             value = '1'
 
+                        elif (key == 'Mode') and (template_name == 'NirissExternalCalibration'):
+                            value = 'imaging'
+
+
                         exposures_dictionary[key].append(value)
 
                     # add keys that were not defined in self.APTObservationParams_keys

--- a/nircam_simulator/scripts/yaml_generator.py
+++ b/nircam_simulator/scripts/yaml_generator.py
@@ -114,11 +114,13 @@ class SimInput:
         if self.instrument.lower() == 'nircam':
             self.psfpath = os.path.join(self.datadir, 'webbpsf_library')
             self.psfbasename = 'nircam'
+            self.psfpixfrac = 0.25
         elif self.instrument.lower() == 'niriss':
             self.datadir2 = '/ifs/jwst/wit/niriss/nircam_ramp_simulation_files'
             self.reference_file_dir =  os.path.join(self.datadir2, 'reference_files')
             self.psfpath = os.path.join(self.datadir2, 'webbpsf_files')
             self.psfbasename = 'niriss'
+            self.psfpixfrac = 0.1
         else:
             raise RuntimeError('Instrument {} is not supported'.format(instrument))
 
@@ -145,7 +147,6 @@ class SimInput:
         self.use_JWST_pipeline = True
         self.use_linearized_darks = False
         self.simdata_output_dir = './'
-        self.psfpixfrac = 0.25
         self.psfwfe = 'predicted'
         self.psfwfegroup = 0
         self.resets_bet_ints = 1 # NIRCam should be 1
@@ -223,8 +224,9 @@ class SimInput:
             final_file = self.table_file + '_with_yaml_parameters.csv'
 
         else:
-            print("WARNING. You must include either an ascii table file of observations.")
-            print("or xml and pointing files from APT plus an ascii siaf table.")
+            print("WARNING. You must include either an ascii table file of observations")
+            print("or xml and pointing files from APT plus an ascii siaf table plus the observation list file.")
+            print('Aborted.')
             sys.exit()
 
         # For each element in the lists below, use the detector name to


### PR DESCRIPTION
This is the first functional version that supports processing a basic NIRISS APT file (#73).
This needs careful review because many changes were made and I did not have an easy way to verify that they don't break the use for NIRCam.

Because NIRISS and NIRCam reference files are located in different locations and have different names, changes to the SimInput __init__ method were made, which imply that mirage can only work on the observations of one instrument at the time (instrument can be 'WFSC', 'NIRCam', ' NIRISS').

If needed I can make the example driver script and the APT file available (eventually we want to have this as a test case).