### PR TITLE
Fixed PSF lib filenames, IPC inversion bug

### DIFF
--- a/nircam_simulator/scripts/catalog_seed_image.py
+++ b/nircam_simulator/scripts/catalog_seed_image.py
@@ -1723,25 +1723,11 @@ class Catalog_seed():
             # Now we need to determine the proper PSF
             # file to read in from the library
             # This depends on the sub-pixel offsets above
-            #a = round(interval * int(numperpix*xfract + 0.5) - 0.5, 1)
-            #b = round(interval * int(numperpix*yfract + 0.5) - 0.5, 1)
-            a = round(interval * int(numperpix*xfract + 0.5) - 0.5, 2)
-            b = round(interval * int(numperpix*yfract + 0.5) - 0.5, 2)
-
-            if a < 0:
-                astr = str(a)[0:5]
-            else:
-                astr = str(a)[0:4]
-            if b < 0:
-                bstr = str(b)[0:5]
-            else:
-                bstr = str(b)[0:4]
-
-            if astr == "0.0":
-                astr = "0.00"
-            if bstr == "0.0":
-                bstr = "0.00"
-
+            a_in = interval * int(numperpix*xfract + 0.5) - 0.5
+            b_in = interval * int(numperpix*yfract + 0.5) - 0.5
+            astr = "{0:.{1}f}".format(a_in, 2)
+            bstr = "{0:.{1}f}".format(b_in, 2)
+   
             #generate the psf file name based on the center of the point source
             #in units of fraction of a pixel
             frag = astr + '_' + bstr

--- a/nircam_simulator/scripts/obs_generator.py
+++ b/nircam_simulator/scripts/obs_generator.py
@@ -1780,7 +1780,7 @@ class Observation():
         if len(dims) == 2:
             subkernel = np.expand_dims(subkernel, axis=3)
             subkernel = np.expand_dims(subkernel, axis=4)
-            dims = subkernel.shape
+        dims = subkernel.shape
             
         # Make sure the total signal in the kernel = 1
         #ave = np.average(subkernel, axis=(0, 1))
@@ -1790,12 +1790,15 @@ class Observation():
         #subkernel *= renorm
 
         delta = subkernel * 0.
-        delta[nyc, nxc] = 1.
+        nyc = dims[0] // 2
+        nxc = dims[1] // 2
+        delta[nyc, nxc, :, :] = 1.
+
         a1 = np.fft.fft2(subkernel, axes=(0, 1)) 
         a2 = np.fft.fft2(delta, axes=(0, 1))
         aout = a2 / a1
         imout = np.fft.ifft2(aout, axes=(0, 1))
-        realout = np.real(imout)
+        #realout = np.real(imout)
         imout1 = np.fft.fftshift(imout, axes=(0, 1))
         realout1 = np.real(imout1)
 


### PR DESCRIPTION
The name of the PSF library file to search for and use was incorrect in the case of a source located at the exact sub-pixel location that the PSF file was for. This was due to unexpected behavior in python's round function. Fix was made such that all sub-pixel locations now have two digits to the right of the decimal point (e.g 0.20). PSF filenames follow this format.

Also made a small tweak to the IPC inversion function, where two variable names were undefined. 
Checks using NIRISS and NIRCam PSF kernels were successful. 